### PR TITLE
feat: Add Wall Tool and Tool Manager for editor tools management

### DIFF
--- a/src/js/TerrainBuilder.js
+++ b/src/js/TerrainBuilder.js
@@ -1091,13 +1091,9 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 		// Initialize the tool manager with all the properties tools might need
 		const terrainBuilderProps = {
 			scene,
-			gl,
 			terrainRef: terrainRef,
 			currentBlockTypeRef: currentBlockTypeRef,
-			undoRedoManager: undoRedoManager,
 			previewPositionRef: previewPositionRef,
-			refreshMeshes: refreshBlockMeshes,
-			renderer: gl, // Use gl as the renderer
 			terrainBuilderRef: ref, // Add a reference to this component
 			// Add any other properties tools might need
 		};

--- a/src/js/TerrainBuilder.js
+++ b/src/js/TerrainBuilder.js
@@ -9,6 +9,9 @@ import { THRESHOLD_FOR_PLACING, BLOCK_INSTANCED_MESH_CAPACITY } from "./Constant
 import { refreshBlockTools } from "./components/BlockToolsSidebar";
 import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils";
 
+// Import tools
+import { ToolManager, WallTool } from "./tools";
+
 let meshesNeedsRefresh = false;
 
 // Modify the blockTypes definition to be a function that can be updated
@@ -208,6 +211,9 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 	const tempVec2Ref = useRef(new THREE.Vector2());
 	const tempVec2_2Ref = useRef(new THREE.Vector2());
 
+	// Add Tool Manager ref
+	const toolManagerRef = useRef(null);
+
 	//* TERRAIN UPDATE FUNCTIONS *//
 	//* TERRAIN UPDATE FUNCTIONS *//
 	//* TERRAIN UPDATE FUNCTIONS *//
@@ -399,6 +405,16 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 	/// Placement and Modification Functions ///
 
 	const handleMouseDown = (event) => {
+		// If a tool is active, delegate the event to it
+		if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+			const intersection = getRaycastIntersection();
+			if (intersection) {
+				toolManagerRef.current.handleMouseDown(event, intersection.point, event.button);
+				return; // Let the tool handle it
+			}
+		}
+		
+		// Otherwise use default behavior
 		if (event.button === 0) {
 			isPlacingRef.current = true;
 			isFirstBlockRef.current = true;
@@ -590,6 +606,14 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 		const intersection = getRaycastIntersection();
 		if (!intersection) return;
 
+		// If a tool is active, delegate the mouse move event to it
+		if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+			toolManagerRef.current.handleMouseMove(null, intersection.point);
+			
+			// Also call tool update method to allow for continuous updates
+			toolManagerRef.current.update();
+		}
+
 		if (!currentBlockTypeRef?.current?.isEnvironment) {
 			// Reuse vector for grid position calculation
 			tempVectorRef.current.copy(intersection.point);
@@ -681,6 +705,16 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 
 	// Move undo state saving to handlePointerUp
 	const handleMouseUp = (event) => {
+		// If a tool is active, delegate the event to it
+		if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+			const intersection = getRaycastIntersection();
+			if (intersection) {
+				toolManagerRef.current.handleMouseUp(event, intersection.point);
+				return; // Let the tool handle it
+			}
+		}
+		
+		// Otherwise use default behavior
 		if (event.button === 0) {
 			isPlacingRef.current = false;
 			// Clear recently placed blocks
@@ -1054,6 +1088,26 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 				});
 		}
 
+		// Initialize the tool manager with all the properties tools might need
+		const terrainBuilderProps = {
+			scene,
+			gl,
+			terrainRef: terrainRef,
+			currentBlockTypeRef: currentBlockTypeRef,
+			undoRedoManager: undoRedoManager,
+			previewPositionRef: previewPositionRef,
+			refreshMeshes: refreshBlockMeshes,
+			renderer: gl, // Use gl as the renderer
+			terrainBuilderRef: ref, // Add a reference to this component
+			// Add any other properties tools might need
+		};
+		
+		toolManagerRef.current = new ToolManager(terrainBuilderProps);
+		
+		// Register tools
+		const wallTool = new WallTool(terrainBuilderProps);
+		toolManagerRef.current.registerTool("wall", wallTool);
+		
 		initialize();
 
 		return () => {
@@ -1122,6 +1176,7 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 		updateTerrainFromToolBar,
 		getCurrentTerrainData,
 		clearMap,
+
 		/**
 		 * Force a DB reload of terrain and then rebuild it
 		 */
@@ -1139,6 +1194,23 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 				console.error("Error reloading terrain from DB:", err);
 			}
 		},
+		// Add method to activate a tool
+		activateTool: (toolName) => {
+			if (toolManagerRef.current) {
+				return toolManagerRef.current.activateTool(toolName);
+			}
+			return false;
+		},
+		// Add method to get active tool name
+		getActiveToolName: () => {
+			if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+				return toolManagerRef.current.getActiveTool().name;
+			}
+			return null;
+		},
+
+		updateTerrainBlocks,
+	
 	}));
 
 	// Add resize listener to update canvasRect
@@ -1149,6 +1221,68 @@ function TerrainBuilder({ onSceneReady, previewPositionToAppJS, currentBlockType
 		window.addEventListener('resize', handleResize);
 		return () => window.removeEventListener('resize', handleResize);
 	}, []);
+
+	// Add key event handlers to delegate to tools
+	const handleKeyDown = (event) => {
+		if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+			toolManagerRef.current.handleKeyDown(event);
+		}
+	};
+	
+	const handleKeyUp = (event) => {
+		if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
+			toolManagerRef.current.handleKeyUp(event);
+		}
+	};
+	
+	// Update useEffect to add key event listeners
+	useEffect(() => {
+		window.addEventListener('keydown', handleKeyDown);
+		window.addEventListener('keyup', handleKeyUp);
+		
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown);
+			window.removeEventListener('keyup', handleKeyUp);
+		};
+	}, []);
+
+	// Add cleanup for tool manager when component unmounts
+	useEffect(() => {
+		return () => {
+			if (toolManagerRef.current) {
+				toolManagerRef.current.dispose();
+				toolManagerRef.current = null;
+			}
+		};
+	}, []);
+
+	
+	// update the terrain blocks for added and removed blocks
+	const updateTerrainBlocks = (addedBlocks, removedBlocks) => {
+		console.log('Updating terrain blocks:', addedBlocks);
+		// If we placed any blocks, update the scene
+		if (Object.keys(addedBlocks).length > 0 || Object.keys(removedBlocks).length > 0) {
+			
+			buildUpdateTerrain();
+			playPlaceSound();
+
+			// Save to database
+			DatabaseManager.saveData(STORES.TERRAIN, "current", terrainRef.current);
+
+			// Handle undo/redo correctly
+			if (undoRedoManager) {
+				// Create the changes object in the format expected by saveUndo
+				const changes = {
+					terrain: {
+						added: addedBlocks,
+						removed: removedBlocks
+					}
+				};
+				// Save the undo state
+				undoRedoManager.saveUndo(changes);
+			}
+		}
+	}
 
 	//// HTML Return Render
 	return (

--- a/src/js/components/QuickTips.js
+++ b/src/js/components/QuickTips.js
@@ -1,29 +1,44 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import '../../css/QuickTips.css';
 import { FaTimes } from 'react-icons/fa';
-
+import QuickTipsManager from './QuickTipsManager';
 
 const QuickTips = () => {
-
     const [isVisible, setIsVisible] = useState(true);
-
+    const [tipText, setTipText] = useState(QuickTipsManager.getToolTip());
+    
+    useEffect(() => {
+        // Register a listener to update the tip text
+        const handleTipChange = (newTip) => {
+            setTipText(newTip);
+        };
+        
+        // Add the listener
+        QuickTipsManager.addListener(handleTipChange);
+        
+        // Clean up when component unmounts
+        return () => {
+            QuickTipsManager.removeListener(handleTipChange);
+        };
+    }, []);
+    
     const toggleVisibility = () => {
         setIsVisible(!isVisible);
     }
 
-  return (
-    isVisible && (
-        <div className="quick-tips-container">
-            <div className="quick-tips">
-                <p className="tip-title">Quick Tips:</p>
-                <p className="tip-text">Move the camera with W, A, S, D. Right click to rotate. Middle click to drag-move.</p>
-                <div className="tip-close-button" onClick={toggleVisibility}>
-                    <FaTimes />
+    return (
+        isVisible && (
+            <div className="quick-tips-container">
+                <div className="quick-tips">
+                    <p className="tip-title">Quick Tips:</p>
+                    <p className="tip-text">{tipText}</p>
+                    <div className="tip-close-button" onClick={toggleVisibility}>
+                        <FaTimes />
+                    </div>
                 </div>
             </div>
-        </div>
-    )
-  );
+        )
+    );
 };
 
 export default QuickTips;

--- a/src/js/components/QuickTipsManager.js
+++ b/src/js/components/QuickTipsManager.js
@@ -1,0 +1,67 @@
+/**
+ * QuickTipsManager - A simple global state manager for tooltips
+ * 
+ * This manager allows setting and getting the current tool tip text
+ * from anywhere in the application without complex React state management.
+ */
+
+class QuickTipsManager {
+	static listeners = [];
+	static currentTip = QuickTipsManager.defaultTip;
+    static defaultTip = "Move the camera with W, A, S, D. Right click to rotate. Middle click to drag-move.";
+
+	/**
+	 * Set the current tool tip text
+	 * @param {string} tipText - The tooltip text to display
+	 */
+	static setToolTip(tipText) {
+		QuickTipsManager.currentTip = tipText;
+		// Notify all listeners
+		QuickTipsManager.listeners.forEach(listener => {
+			try {
+				listener(tipText);
+			} catch (error) {
+				console.error('Error notifying tooltip listener:', error);
+			}
+		});
+	}
+	static setToDefaultTip() {
+		QuickTipsManager.currentTip = QuickTipsManager.defaultTip;
+		// Notify all listeners
+		QuickTipsManager.listeners.forEach(listener => {
+			try {
+				listener(QuickTipsManager.defaultTip);
+			} catch (error) {
+				console.error('Error notifying tooltip listener:', error);
+			}
+		});
+	}
+
+	/**
+	 * Get the current tool tip text
+	 * @returns {string} The current tooltip text
+	 */
+	static getToolTip() {
+		return QuickTipsManager.currentTip;
+	}
+
+	/**
+	 * Add a listener function to be called when the tip changes
+	 * @param {Function} listener - Function to call with the new tip text
+	 */
+	static addListener(listener) {
+		if (typeof listener === 'function') {
+			QuickTipsManager.listeners.push(listener);
+		}
+	}
+
+	/**
+	 * Remove a previously added listener
+	 * @param {Function} listener - The listener to remove
+	 */
+	static removeListener(listener) {
+		QuickTipsManager.listeners = QuickTipsManager.listeners.filter(l => l !== listener);
+	}
+}
+
+export default QuickTipsManager; 

--- a/src/js/components/ToolBar.js
+++ b/src/js/components/ToolBar.js
@@ -500,7 +500,7 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 							</button>
 						</Tooltip>
 						<div className="control-divider-vertical"></div>
-						<Tooltip text="Wall Tool - Click to place wall start, click again to place. Hold Ctrl to erase. q cancels">
+						<Tooltip text="Wall Tool - Click to place wall start, click again to place. Hold Ctrl to erase. Press 1 and 2 to adjust height. q cancels">
 							<button
 								onClick={() => handleToolToggle("wall")}
 								className={`control-button ${activeTool === "wall" ? "selected" : ""}`}>

--- a/src/js/components/ToolBar.js
+++ b/src/js/components/ToolBar.js
@@ -6,9 +6,7 @@ import "../../css/ToolBar.css";
 import { generatePerlinNoise } from "perlin-noise";
 import { 
 	exportMapFile,
-	exportFullAssetPack, 
 	importMap,
-	importAssetPack
 } from '../ImportExport';
 import { DISABLE_ASSET_PACK_IMPORT_EXPORT } from '../Constants';
 const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, setAxisLockEnabled, placementSize, setPlacementSize, setGridSize, undoRedoManager, currentBlockType, environmentBuilderRef }) => {
@@ -502,7 +500,10 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 						<div className="control-divider-vertical"></div>
 						<Tooltip text="Wall Tool - Click to place wall start, click again to place. Hold Ctrl to erase. Press 1 and 2 to adjust height. q cancels">
 							<button
-								onClick={() => handleToolToggle("wall")}
+								onClick={() => {
+									handleToolToggle("wall");
+									setPlacementSize("single");
+								}}
 								className={`control-button ${activeTool === "wall" ? "selected" : ""}`}>
 								<FaDrawPolygon />
 							</button>

--- a/src/js/components/ToolBar.js
+++ b/src/js/components/ToolBar.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { FaPlus, FaMinus, FaCube, FaBorderStyle, FaLock, FaLockOpen, FaUndo, FaRedo, FaExpand, FaTrash, FaCircle, FaSquare, FaMountain } from "react-icons/fa";
+import { FaPlus, FaMinus, FaCube, FaBorderStyle, FaLock, FaLockOpen, FaUndo, FaRedo, FaExpand, FaTrash, FaCircle, FaSquare, FaMountain, FaDrawPolygon } from "react-icons/fa";
 import Tooltip from "../components/Tooltip";
 import { DatabaseManager, STORES } from "../DatabaseManager";
 import "../../css/ToolBar.css";
@@ -39,6 +39,10 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 	// Add state for undo/redo button availability
 	const [canUndo, setCanUndo] = useState(true);
 	const [canRedo, setCanRedo] = useState(false);
+
+	// Add state for active tool tracking
+	const [activeTool, setActiveTool] = useState(null);
+
 	let startPos = {
 		x: 0,
 		y: 0,
@@ -162,7 +166,16 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 	};
 
 	const handleClearMap = () => {
-		terrainBuilderRef.current?.clearMap();
+		// Deactivate any active tool
+		if (activeTool) {
+			terrainBuilderRef.current?.activateTool(null);
+			setActiveTool(null);
+		}
+		
+		// Confirm before clearing
+		if (window.confirm("Are you sure you want to clear the map? This cannot be undone.")) {
+			terrainBuilderRef.current?.clearMap();
+		}
 	};
 
 	const generateTerrain = () => {
@@ -322,6 +335,33 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 		}
 	};
 
+	// Add function to toggle tools
+	const handleToolToggle = (toolName) => {
+		if (activeTool === toolName) {
+			// Deactivate the current tool
+			terrainBuilderRef.current?.activateTool(null);
+			setActiveTool(null);
+		} else {
+			// Activate the requested tool
+			const success = terrainBuilderRef.current?.activateTool(toolName);
+			if (success) {
+				setActiveTool(toolName);
+			}
+		}
+	};
+
+	// Update handleModeChange to deactivate tools when switching modes
+	const handleModeChangeWithToolReset = (newMode) => {
+		// Deactivate any active tool
+		if (activeTool) {
+			terrainBuilderRef.current?.activateTool(null);
+			setActiveTool(null);
+		}
+		
+		// Call the original handleModeChange function
+		handleModeChange(newMode);
+	};
+
 	return (
 		<>
 			<div className="controls-container">
@@ -385,14 +425,14 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 					<div className="control-button-wrapper">
 						<Tooltip text="Add blocks">
 							<button
-								onClick={() => handleModeChange("add")}
+								onClick={() => handleModeChangeWithToolReset("add")}
 								className={`control-button ${mode === "add" ? "selected" : ""}`}>
 								<FaPlus />
 							</button>
 						</Tooltip>
 						<Tooltip text="Remove blocks">
 							<button
-								onClick={() => handleModeChange("remove")}
+								onClick={() => handleModeChangeWithToolReset("remove")}
 								className={`control-button ${mode === "remove" ? "selected" : ""}`}>
 								<FaMinus />
 							</button>
@@ -404,6 +444,7 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 								{axisLockEnabled ? <FaLock /> : <FaLockOpen />}
 							</button>
 						</Tooltip>
+						
 						<Tooltip text="Undo (Ctrl+Z)">
 							<button
 								onClick={() => undoRedoManager.handleUndo()}
@@ -458,10 +499,20 @@ const ToolBar = ({ terrainBuilderRef, mode, handleModeChange, axisLockEnabled, s
 								<FaSquare style={{ width: "20px", height: "20px" }} />
 							</button>
 						</Tooltip>
+						<div className="control-divider-vertical"></div>
+						<Tooltip text="Wall Tool - Click to place wall start, click again to place. Hold Ctrl to erase. q cancels">
+							<button
+								onClick={() => handleToolToggle("wall")}
+								className={`control-button ${activeTool === "wall" ? "selected" : ""}`}>
+								<FaDrawPolygon />
+							</button>
+						</Tooltip>
 					</div>
 					<div className="control-label">Placement Tools</div>
+					
 				</div>
 				<div className="control-group">
+					
 					<div className="control-button-wrapper">
 						<Tooltip text="Generate solid cube">
 							<button

--- a/src/js/tools/BaseTool.js
+++ b/src/js/tools/BaseTool.js
@@ -10,6 +10,7 @@ class BaseTool {
     this.terrainBuilder = terrainBuilder;
     this.active = false;
     this.name = "BaseTool";
+    this.tooltip = "Tool not implemented";
   }
 
   /**

--- a/src/js/tools/BaseTool.js
+++ b/src/js/tools/BaseTool.js
@@ -1,0 +1,90 @@
+/**
+ * BaseTool.js - Base class for all editor tools
+ * 
+ * This provides the foundation for creating custom tools in the world editor.
+ * All specific tools (like WallTool, PaintTool, etc.) should extend this class.
+ */
+
+class BaseTool {
+  constructor(terrainBuilder) {
+    this.terrainBuilder = terrainBuilder;
+    this.active = false;
+    this.name = "BaseTool";
+  }
+
+  /**
+   * Called when the tool is activated
+   */
+  onActivate() {
+    this.active = true;
+    console.log(`${this.name} activated`);
+  }
+
+  /**
+   * Called when the tool is deactivated
+   */
+  onDeactivate() {
+    this.active = false;
+    console.log(`${this.name} deactivated`);
+  }
+
+  /**
+   * Handle mouse down events
+   * @param {Object} event - The mouse event
+   * @param {THREE.Vector3} position - The world position
+   * @param {number} button - Mouse button (0 = left, 2 = right)
+   */
+  handleMouseDown(event, position, button) {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Handle mouse move events
+   * @param {Object} event - The mouse event
+   * @param {THREE.Vector3} position - The world position
+   */
+  handleMouseMove(event, position) {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Handle mouse up events
+   * @param {Object} event - The mouse event
+   * @param {THREE.Vector3} position - The world position
+   */
+  handleMouseUp(event, position) {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Handle key down events
+   * @param {Object} event - The key event
+   */
+  handleKeyDown(event) {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Handle key up events
+   * @param {Object} event - The key event
+   */
+  handleKeyUp(event) {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Update function called on each frame
+   */
+  update() {
+    // To be implemented by child classes
+  }
+
+  /**
+   * Clean up any resources when the tool is no longer needed
+   */
+  dispose() {
+    // To be implemented by child classes
+  }
+}
+
+export default BaseTool; 

--- a/src/js/tools/ToolManager.js
+++ b/src/js/tools/ToolManager.js
@@ -1,0 +1,151 @@
+/**
+ * ToolManager.js - Manages and coordinates all editor tools
+ * 
+ * This class is responsible for initializing tools, activating/deactivating them,
+ * and directing input events to the currently active tool.
+ */
+
+class ToolManager {
+  constructor(terrainBuilderProps) {
+    // Validate that we have the minimal required properties
+    if (!terrainBuilderProps.scene) {
+      console.error('ToolManager initialized without scene property');
+    }
+    
+    // Store reference to terrainBuilder properties for tools to use
+    this.terrainBuilder = terrainBuilderProps;
+    this.tools = {};
+    this.activeTool = null;
+    
+    console.log('ToolManager initialized with properties:', 
+      Object.keys(terrainBuilderProps).filter(key => terrainBuilderProps[key] !== undefined));
+  }
+
+  /**
+   * Register a tool with the manager
+   * @param {string} toolName - Unique identifier for the tool
+   * @param {BaseTool} tool - Instance of a tool extending BaseTool
+   */
+  registerTool(toolName, tool) {
+    if (!toolName || typeof toolName !== 'string') {
+      console.error('Invalid tool name provided to registerTool:', toolName);
+      return;
+    }
+    
+    if (!tool || typeof tool.onActivate !== 'function') {
+      console.error('Invalid tool object provided to registerTool:', tool);
+      return;
+    }
+    
+    this.tools[toolName] = tool;
+    console.log(`Registered tool: ${toolName}`);
+  }
+
+  /**
+   * Activate a specific tool by name
+   * @param {string} toolName - Name of the tool to activate
+   */
+  activateTool(toolName) {
+    // Deactivate current tool if there is one
+    if (this.activeTool) {
+      this.activeTool.onDeactivate();
+    }
+
+    // If toolName is null or undefined, just deactivate the current tool
+    if (!toolName) {
+      this.activeTool = null;
+      console.log('All tools deactivated');
+      return true;
+    }
+
+    // Activate the new tool
+    if (this.tools[toolName]) {
+      this.activeTool = this.tools[toolName];
+      this.activeTool.onActivate();
+      console.log(`Activated tool: ${toolName}`);
+      return true;
+    } else {
+      console.warn(`Tool not found: ${toolName}`);
+      this.activeTool = null;
+      return false;
+    }
+  }
+
+  /**
+   * Get the currently active tool
+   * @returns {BaseTool|null} The active tool or null if none is active
+   */
+  getActiveTool() {
+    return this.activeTool;
+  }
+
+  /**
+   * Handle mouse down events by forwarding to the active tool
+   */
+  handleMouseDown(event, position, button) {
+    if (this.activeTool) {
+      this.activeTool.handleMouseDown(event, position, button);
+    }
+  }
+
+  /**
+   * Handle mouse move events by forwarding to the active tool
+   */
+  handleMouseMove(event, position) {
+    if (this.activeTool) {
+      this.activeTool.handleMouseMove(event, position);
+    }
+  }
+
+  /**
+   * Handle mouse up events by forwarding to the active tool
+   */
+  handleMouseUp(event, position) {
+    if (this.activeTool) {
+      this.activeTool.handleMouseUp(event, position);
+    }
+  }
+
+  /**
+   * Handle key down events by forwarding to the active tool
+   */
+  handleKeyDown(event) {
+    if (this.activeTool) {
+      this.activeTool.handleKeyDown(event);
+    }
+  }
+
+  /**
+   * Handle key up events by forwarding to the active tool
+   */
+  handleKeyUp(event) {
+    if (this.activeTool) {
+      this.activeTool.handleKeyUp(event);
+    }
+  }
+
+  /**
+   * Update the active tool
+   */
+  update() {
+    if (this.activeTool) {
+      this.activeTool.update();
+    }
+  }
+
+  /**
+   * Clean up all tools when no longer needed
+   */
+  dispose() {
+    Object.values(this.tools).forEach(tool => {
+      if (typeof tool.dispose === 'function') {
+        tool.dispose();
+      }
+    });
+    
+    this.tools = {};
+    this.activeTool = null;
+  }
+}
+
+export default ToolManager; 

--- a/src/js/tools/ToolManager.js
+++ b/src/js/tools/ToolManager.js
@@ -4,148 +4,162 @@
  * This class is responsible for initializing tools, activating/deactivating them,
  * and directing input events to the currently active tool.
  */
+import QuickTipsManager from '../components/QuickTipsManager';
+
 
 class ToolManager {
-  constructor(terrainBuilderProps) {
-    // Validate that we have the minimal required properties
-    if (!terrainBuilderProps.scene) {
-      console.error('ToolManager initialized without scene property');
-    }
-    
-    // Store reference to terrainBuilder properties for tools to use
-    this.terrainBuilder = terrainBuilderProps;
-    this.tools = {};
-    this.activeTool = null;
-    
-    console.log('ToolManager initialized with properties:', 
-      Object.keys(terrainBuilderProps).filter(key => terrainBuilderProps[key] !== undefined));
-  }
+	constructor(terrainBuilderProps) {
+		// Validate that we have the minimal required properties
+		if (!terrainBuilderProps.scene) {
+			console.error('ToolManager initialized without scene property');
+		}
 
-  /**
-   * Register a tool with the manager
-   * @param {string} toolName - Unique identifier for the tool
-   * @param {BaseTool} tool - Instance of a tool extending BaseTool
-   */
-  registerTool(toolName, tool) {
-    if (!toolName || typeof toolName !== 'string') {
-      console.error('Invalid tool name provided to registerTool:', toolName);
-      return;
-    }
-    
-    if (!tool || typeof tool.onActivate !== 'function') {
-      console.error('Invalid tool object provided to registerTool:', tool);
-      return;
-    }
-    
-    this.tools[toolName] = tool;
-    console.log(`Registered tool: ${toolName}`);
-  }
+		// Store reference to terrainBuilder properties for tools to use
+		this.terrainBuilder = terrainBuilderProps;
+		this.tools = {};
+		this.activeTool = null;
+		this.toolChangeListeners = []; // Add array for tool change listeners
 
-  /**
-   * Activate a specific tool by name
-   * @param {string} toolName - Name of the tool to activate
-   */
-  activateTool(toolName) {
-    // Deactivate current tool if there is one
-    if (this.activeTool) {
-      this.activeTool.onDeactivate();
-    }
+		console.log('ToolManager initialized with properties:',
+			Object.keys(terrainBuilderProps).filter(key => terrainBuilderProps[key] !== undefined));
+	}
 
-    // If toolName is null or undefined, just deactivate the current tool
-    if (!toolName) {
-      this.activeTool = null;
-      console.log('All tools deactivated');
-      return true;
-    }
+	/**
+	 * Register a new tool with the manager
+	 * @param {string} toolName - Name to register the tool under
+	 * @param {BaseTool} tool - Tool instance to register
+	 */
+	registerTool(toolName, tool) {
+		if (!toolName || typeof toolName !== 'string') {
+			console.error('Invalid tool name provided to registerTool:', toolName);
+			return;
+		}
 
-    // Activate the new tool
-    if (this.tools[toolName]) {
-      this.activeTool = this.tools[toolName];
-      this.activeTool.onActivate();
-      console.log(`Activated tool: ${toolName}`);
-      return true;
-    } else {
-      console.warn(`Tool not found: ${toolName}`);
-      this.activeTool = null;
-      return false;
-    }
-  }
+		if (!tool || typeof tool.onActivate !== 'function') {
+			console.error('Invalid tool object provided to registerTool:', tool);
+			return;
+		}
 
-  /**
-   * Get the currently active tool
-   * @returns {BaseTool|null} The active tool or null if none is active
-   */
-  getActiveTool() {
-    return this.activeTool;
-  }
+		this.tools[toolName] = tool;
+		console.log(`Registered tool: ${toolName}`);
+	}
 
-  /**
-   * Handle mouse down events by forwarding to the active tool
-   */
-  handleMouseDown(event, position, button) {
-    if (this.activeTool) {
-      this.activeTool.handleMouseDown(event, position, button);
-    }
-  }
+	
+	/**
+	 * Activate a specific tool by name
+	 * @param {string} toolName - Name of the tool to activate
+	 */
+	activateTool(toolName) {
+		// Deactivate current tool if there is one
+		if (this.activeTool) {
+			this.activeTool.onDeactivate();
+		}
 
-  /**
-   * Handle mouse move events by forwarding to the active tool
-   */
-  handleMouseMove(event, position) {
-    if (this.activeTool) {
-      this.activeTool.handleMouseMove(event, position);
-    }
-  }
+		// If toolName is null or undefined, just deactivate the current tool
+		if (!toolName) {
+			this.activeTool = null;
+			console.log('All tools deactivated');
+			// Reset the QuickTip to default
+			QuickTipsManager.setToDefaultTip();
+			return true;
+		}
 
-  /**
-   * Handle mouse up events by forwarding to the active tool
-   */
-  handleMouseUp(event, position) {
-    if (this.activeTool) {
-      this.activeTool.handleMouseUp(event, position);
-    }
-  }
+		// Activate the new tool
+		if (this.tools[toolName]) {
+			this.activeTool = this.tools[toolName];
+			this.activeTool.onActivate();
+			console.log(`Activated tool: ${toolName}`);
 
-  /**
-   * Handle key down events by forwarding to the active tool
-   */
-  handleKeyDown(event) {
-    if (this.activeTool) {
-      this.activeTool.handleKeyDown(event);
-    }
-  }
+			// Update the QuickTip with the tool's tooltip
+			if (this.activeTool.tooltip) {
+				QuickTipsManager.setToolTip(this.activeTool.tooltip);
+			}
 
-  /**
-   * Handle key up events by forwarding to the active tool
-   */
-  handleKeyUp(event) {
-    if (this.activeTool) {
-      this.activeTool.handleKeyUp(event);
-    }
-  }
+			return true;
+		} else {
+			console.warn(`Tool not found: ${toolName}`);
+			this.activeTool = null;
+			// Reset the QuickTip to default
+			QuickTipsManager.setToDefaultTip();
+			return false;
+		}
+	}
 
-  /**
-   * Update the active tool
-   */
-  update() {
-    if (this.activeTool) {
-      this.activeTool.update();
-    }
-  }
+	/**
+	 * Get the currently active tool
+	 * @returns {BaseTool|null} The active tool or null if none is active
+	 */
+	getActiveTool() {
+		return this.activeTool;
+	}
 
-  /**
-   * Clean up all tools when no longer needed
-   */
-  dispose() {
-    Object.values(this.tools).forEach(tool => {
-      if (typeof tool.dispose === 'function') {
-        tool.dispose();
-      }
-    });
-    
-    this.tools = {};
-    this.activeTool = null;
-  }
+	/**
+	 * Handle mouse down events by forwarding to the active tool
+	 */
+	handleMouseDown(event, position, button) {
+		if (this.activeTool) {
+			this.activeTool.handleMouseDown(event, position, button);
+		}
+	}
+
+	/**
+	 * Handle mouse move events by forwarding to the active tool
+	 */
+	handleMouseMove(event, position) {
+		if (this.activeTool) {
+			this.activeTool.handleMouseMove(event, position);
+		}
+	}
+
+	/**
+	 * Handle mouse up events by forwarding to the active tool
+	 */
+	handleMouseUp(event, position) {
+		if (this.activeTool) {
+			this.activeTool.handleMouseUp(event, position);
+		}
+	}
+
+	/**
+	 * Handle key down events by forwarding to the active tool
+	 */
+	handleKeyDown(event) {
+		if (this.activeTool) {
+			this.activeTool.handleKeyDown(event);
+		}
+	}
+
+	/**
+	 * Handle key up events by forwarding to the active tool
+	 */
+	handleKeyUp(event) {
+		if (this.activeTool) {
+			this.activeTool.handleKeyUp(event);
+		}
+	}
+
+	/**
+	 * Update the active tool
+	 */
+	update() {
+		if (this.activeTool) {
+			this.activeTool.update();
+		}
+	}
+
+	/**
+	 * Clean up all tools when no longer needed
+	 */
+	dispose() {
+		Object.values(this.tools).forEach(tool => {
+			if (typeof tool.dispose === 'function') {
+				tool.dispose();
+			}
+		});
+
+		this.tools = {};
+		this.activeTool = null;
+	}
 }
 
 export default ToolManager; 

--- a/src/js/tools/WallTool.js
+++ b/src/js/tools/WallTool.js
@@ -28,9 +28,7 @@ class WallTool extends BaseTool {
 			this.terrainRef = terrainBuilderProps.terrainRef;
 			this.currentBlockTypeRef = terrainBuilderProps.currentBlockTypeRef;
 			this.scene = terrainBuilderProps.scene;
-			this.renderer = terrainBuilderProps.renderer;
 			this.toolManagerRef = terrainBuilderProps.toolManagerRef;
-			this.refreshMeshes = terrainBuilderProps.refreshMeshes;
 			this.terrainBuilderRef = terrainBuilderProps.terrainBuilderRef;
 
 			// Add missing preview position ref

--- a/src/js/tools/WallTool.js
+++ b/src/js/tools/WallTool.js
@@ -1,0 +1,458 @@
+/**
+ * WallTool.js - Tool for placing walls in the world editor
+ * 
+ * This tool handles wall placement, previewing, and manipulation.
+ */
+
+import * as THREE from 'three';
+import BaseTool from './BaseTool';
+
+class WallTool extends BaseTool {
+	/**
+	 * Creates a new WallTool instance
+	 */
+	constructor(terrainBuilderProps) {
+		console.log('WallTool initialized');
+		super(terrainBuilderProps);
+
+		// CAREFUL: We need to explicitly get properties from the terrainBuilder
+		this.name = "WallTool";
+		this.wallHeight = 1;
+		this.isCtrlPressed = false;
+		this.wallStartPosition = null;
+		this.wallPreviewMeshes = [];
+		this.wallDebugMesh = null;
+
+		// IMPORTANT: Get the required references from the terrainBuilder
+		if (terrainBuilderProps) {
+			this.terrainRef = terrainBuilderProps.terrainRef;
+			this.currentBlockTypeRef = terrainBuilderProps.currentBlockTypeRef;
+			this.scene = terrainBuilderProps.scene;
+			this.renderer = terrainBuilderProps.renderer;
+			this.toolManagerRef = terrainBuilderProps.toolManagerRef;
+			this.refreshMeshes = terrainBuilderProps.refreshMeshes;
+			this.terrainBuilderRef = terrainBuilderProps.terrainBuilderRef;
+
+			// Add missing preview position ref
+			this.previewPositionRef = terrainBuilderProps.previewPositionRef;
+			
+			// Set a global reference for tools
+			window.activeTool = this.name;
+
+			// Only set up context menu prevention if we have a renderer
+		} else {
+			console.error('WallTool: terrainBuilderProps is undefined in constructor');
+		}
+	}
+
+	onActivate() {
+		super.onActivate();
+
+		// Log activation details for debugging
+		console.log('WallTool activated');
+		console.log('terrainRef exists:', !!this.terrainRef);
+		console.log('terrainRef.current exists:', this.terrainRef && !!this.terrainRef.current);
+		console.log('currentBlockTypeRef exists:', !!this.currentBlockTypeRef);
+		console.log('currentBlockTypeRef.current exists:', this.currentBlockTypeRef && !!this.currentBlockTypeRef.current);
+
+		// Initialize empty objects if needed
+		if (this.terrainRef && !this.terrainRef.current) {
+			console.log('Initializing empty terrainRef.current in onActivate');
+			this.terrainRef.current = {};
+		}
+
+	}
+
+	onDeactivate() {
+		super.onDeactivate();
+		this.removeWallPreview();
+		this.wallStartPosition = null;
+	}
+
+	/**
+	 * Handles mouse down events for wall placement
+	 */
+	handleMouseDown(event, position, button) {
+		// Safety check - if position is undefined, we can't do anything
+		if (!position) {
+			console.error('WallTool: position is undefined in handleMouseDown');
+			return;
+		}
+
+		// Left-click to place wall or set starting point
+		if (button === 0) {
+			if (this.wallStartPosition) {
+				// Make sure the terrain reference is valid before placing
+				if (!this.terrainRef) {
+					console.error('WallTool: terrainRef is undefined when attempting to place wall');
+					this.wallStartPosition = null;
+					this.removeWallPreview();
+					return;
+				}
+
+				if (!this.terrainRef.current) {
+					console.log('WallTool: terrainRef.current is undefined, initializing empty object');
+					this.terrainRef.current = {};
+				}
+
+				// Perform the appropriate action based on Ctrl key state
+				if (this.isCtrlPressed) {
+					this.eraseWall(this.wallStartPosition, position, this.wallHeight);
+				} else {
+					this.placeWall(this.wallStartPosition, position, this.wallHeight);
+				}
+
+				// Reset the start position for a new wall
+				this.wallStartPosition = null;
+				this.removeWallPreview();
+				// playPlaceSound();
+			} else {
+				// Set start position for a new wall
+				console.log('Setting wall start position:', position);
+				this.wallStartPosition = position.clone();
+			}
+		}
+	}
+
+	/**
+	 * Handles mouse move events for wall preview
+	 */
+	handleMouseMove(event, position) {
+		if (this.wallStartPosition) {
+			this.updateWallPreview(this.wallStartPosition, position);
+		}
+	}
+
+	/**
+	 * Updates the wall height
+	 */
+	setWallHeight(height) {
+		console.log('Setting wall height to:', Math.max(1, height));
+		this.wallHeight = Math.max(1, height);
+
+		// Update preview if it exists - add safety check for previewPositionRef
+		if (this.wallStartPosition && this.previewPositionRef && this.previewPositionRef.current) {
+			this.updateWallPreview(this.wallStartPosition, this.previewPositionRef.current);
+		} else {
+			console.log('Wall preview not updated - missing references:', {
+				wallStartPosition: !!this.wallStartPosition,
+				previewPositionRef: !!this.previewPositionRef,
+				previewPositionRefCurrent: this.previewPositionRef && !!this.previewPositionRef.current
+			});
+		}
+	}
+
+	/**
+	 * Track Ctrl key state for erasing and handle wall height adjustments
+	 */
+	handleKeyDown(event) {
+		if (event.key === 'Control') {
+			console.log('WallTool: Ctrl pressed, switching to erase mode');
+			this.isCtrlPressed = true;
+			this.updateWallPreviewMaterial();
+		} else if (event.key === '1') {
+			console.log('WallTool: Decreasing wall height');
+			this.setWallHeight(this.wallHeight - 1);
+		} else if (event.key === '2') {
+			console.log('WallTool: Increasing wall height');
+			this.setWallHeight(this.wallHeight + 1);
+		} else if (event.key === 'q') {
+			this.removeWallPreview();
+			this.wallStartPosition = null;
+		}
+	}
+
+	/**
+	 * Handle key up events for the tool
+	 */
+	handleKeyUp(event) {
+		if (event.key === 'Control') {
+			console.log('WallTool: Ctrl released, switching to build mode');
+			this.isCtrlPressed = false;
+			this.updateWallPreviewMaterial();
+		}
+	}
+
+	/**
+	 * Place a wall on the terrain
+	 * @param {THREE.Vector3} startPos - The starting position of the wall
+	 * @param {THREE.Vector3} endPos - The ending position of the wall
+	 * @param {number} height - The height of the wall
+	 * @returns {boolean} True if the wall was placed, false otherwise
+	 */
+	placeWall(startPos, endPos, height) {
+
+		if (!startPos || !endPos) return;
+
+		// Convert positions to integers for block placement
+		const startX = Math.round(startPos.x);
+		const startY = Math.round(startPos.y);
+		const startZ = Math.round(startPos.z);
+
+		const endX = Math.round(endPos.x);
+		const endZ = Math.round(endPos.z);
+
+		// Calculate direction vector
+		const dx = Math.sign(endX - startX);
+		const dz = Math.sign(endZ - startZ);
+
+		// Start at the start position
+		let x = startX;
+		let z = startZ;
+
+		// Track added blocks for undo/redo
+		const addedBlocks = {};
+
+		// Iterate along the path until we reach the end position
+		while (x !== endX || z !== endZ) {
+			// For each position along the path, create a column of blocks up to the wall height
+			for (let y = 0; y < height; y++) {
+				const pos = `${x},${startY + y},${z}`;
+				// Only place if there's not already a block here
+				if (!this.terrainRef.current[pos]) {
+					this.terrainRef.current[pos] = this.currentBlockTypeRef.current.id;
+					addedBlocks[pos] = this.currentBlockTypeRef.current.id;
+				}
+			}
+
+			// Move to the next position along the path
+			if (x !== endX) x += dx;
+			if (z !== endZ) z += dz;
+		}
+
+		// Place the final column at the end position
+		for (let y = 0; y < height; y++) {
+			const pos = `${endX},${startY + y},${endZ}`;
+			if (!this.terrainRef.current[pos]) {
+				this.terrainRef.current[pos] = this.currentBlockTypeRef.current.id;
+				addedBlocks[pos] = this.currentBlockTypeRef.current.id;
+			}
+		}
+
+		this.terrainBuilderRef.current.updateTerrainBlocks(
+			addedBlocks,
+			{},
+			this.currentBlockTypeRef.current.id
+		);
+	}
+
+	/**
+	 * Erase a wall from the terrain
+	 * @param {THREE.Vector3} startPos - The starting position of the wall
+	 * @param {THREE.Vector3} endPos - The ending position of the wall
+	 * @param {number} height - The height of the wall
+	 * @returns {boolean} True if the wall was erased, false otherwise
+	 */
+	eraseWall(startPos, endPos, height) {
+
+		if (!startPos || !endPos) {
+			console.error('Invalid start or end position for erasing');
+			return false;
+		}
+
+		// Convert positions to integers for block removal
+		const startX = Math.round(startPos.x);
+		const startY = Math.round(startPos.y);
+		const startZ = Math.round(startPos.z);
+
+		const endX = Math.round(endPos.x);
+		const endY = Math.round(endPos.y);
+		const endZ = Math.round(endPos.z);
+
+		console.log('Erasing wall from', startX, startY, startZ, 'to', endX, endY, endZ);
+
+		// Track removed blocks for undo/redo
+		const removedBlocks = [];
+
+		// Calculate direction vector using Math.sign
+		const dx = Math.sign(endX - startX);
+		const dz = Math.sign(endZ - startZ);
+
+		// Handle single point case
+		if (startX === endX && startZ === endZ) {
+			// Just erase a single column
+			for (let h = 0; h < height; h++) {
+				const posKey = `${startX},${startY + h},${startZ}`;
+				if (this.terrainRef.current[posKey]) {
+					const blockTypeId = this.terrainRef.current[posKey];
+					removedBlocks.push({
+						position: { x: startX, y: startY + h, z: startZ },
+						blockTypeId
+					});
+					delete this.terrainRef.current[posKey];
+				}
+			}
+		} else {
+			// Start at the start position
+			let x = startX;
+			let z = startZ;
+
+			// Iterate along the path until we reach the end position
+			while (x !== endX || z !== endZ) {
+				// For each position along the path, erase a column of blocks
+				for (let h = 0; h < height; h++) {
+					const posKey = `${x},${startY + h},${z}`;
+					if (this.terrainRef.current[posKey]) {
+						const blockTypeId = this.terrainRef.current[posKey];
+						removedBlocks.push({
+							position: { x, y: startY + h, z },
+							blockTypeId
+						});
+						delete this.terrainRef.current[posKey];
+					}
+				}
+
+				// Move to the next position along the path
+				if (x !== endX) x += dx;
+				if (z !== endZ) z += dz;
+			}
+
+			// Process the end position
+			for (let h = 0; h < height; h++) {
+				const posKey = `${endX},${startY + h},${endZ}`;
+				if (this.terrainRef.current[posKey]) {
+					const blockTypeId = this.terrainRef.current[posKey];
+					removedBlocks.push({
+						position: { x: endX, y: startY + h, z: endZ },
+						blockTypeId
+					});
+					delete this.terrainRef.current[posKey];
+				}
+			}
+		}
+
+		this.terrainBuilderRef.current.updateTerrainBlocks(
+			{},
+			removedBlocks
+		);
+	}
+
+	/**
+	 * Updates the wall preview visualization
+	 */
+	updateWallPreview(startPos, endPos) {
+		// Safety checks
+		if (!startPos || !endPos) {
+			return;
+		}
+
+		// Remove existing wall preview if it exists
+		this.removeWallPreview();
+
+		// Don't show a preview if positions aren't valid
+		if (startPos.equals(endPos)) return;
+
+		// Create a geometry for the wall preview
+		const previewGeometry = new THREE.BoxGeometry(1, 1, 1);
+
+		// Use different color based on whether Ctrl is pressed (erase mode)
+		const previewMaterial = new THREE.MeshBasicMaterial({
+			color: this.isCtrlPressed ? 0xff4e4e : 0x4e8eff, // Red for erase, blue for add
+			transparent: true,
+			opacity: 0.5,
+			wireframe: false
+		});
+
+		// Create a group to hold all preview blocks
+		this.wallPreview = new THREE.Group();
+
+		// Convert positions to integers for block placement
+		const startX = Math.round(startPos.x);
+		const startY = Math.round(startPos.y);
+		const startZ = Math.round(startPos.z);
+
+		const endX = Math.round(endPos.x);
+		const endZ = Math.round(endPos.z);
+
+		// Calculate direction vector
+		const dx = Math.sign(endX - startX);
+		const dz = Math.sign(endZ - startZ);
+
+		// Start at the start position
+		let x = startX;
+		let z = startZ;
+
+		// Iterate along the path until we reach the end position
+		while (x !== endX || z !== endZ) {
+			// For each position along the path, create a column of preview blocks
+			for (let y = 0; y < this.wallHeight; y++) {
+				const previewMesh = new THREE.Mesh(previewGeometry, previewMaterial);
+				previewMesh.position.set(x, startY + y, z);
+				this.wallPreview.add(previewMesh);
+			}
+
+			// Move to the next position along the path
+			if (x !== endX) x += dx;
+			if (z !== endZ) z += dz;
+		}
+
+		// Add preview blocks for the end position
+		for (let y = 0; y < this.wallHeight; y++) {
+			const previewMesh = new THREE.Mesh(previewGeometry, previewMaterial);
+			previewMesh.position.set(endX, startY + y, endZ);
+			this.wallPreview.add(previewMesh);
+		}
+
+		// Add the preview to the scene
+		if (this.scene) {
+			this.scene.add(this.wallPreview);
+		}
+	}
+
+	/**
+	 * Updates the wall preview material based on current mode (add or erase)
+	 */
+	updateWallPreviewMaterial() {
+		// Safety check - if no wall preview exists, nothing to update
+		if (!this.wallPreview || !this.wallPreview.children) {
+			return;
+		}
+
+		// Red for erase mode, blue for add mode
+		const color = this.isCtrlPressed ? 0xff4e4e : 0x4e8eff;
+
+		// Update the color of each mesh in the preview
+		this.wallPreview.children.forEach(mesh => {
+			if (mesh && mesh.material) {
+				mesh.material.color.set(color);
+			}
+		});
+	}
+
+	/**
+	 * Removes the wall preview from the scene
+	 */
+	removeWallPreview() {
+		if (this.wallPreview) {
+			this.scene.remove(this.wallPreview);
+			this.wallPreview = null;
+		}
+	}
+
+	/**
+	 * Cleans up resources when the tool is disposed
+	 */
+	dispose() {
+		console.log('WallTool: disposing resources');
+
+		// Remove event listeners
+
+		// Clean up wall preview meshes
+		this.removeWallPreview();
+
+		// Clear references to avoid memory leaks
+		this.terrainRef = null;
+		this.currentBlockTypeRef = null;
+		this.scene = null;
+		this.renderer = null;
+		this.wallStartPosition = null;
+		this.wallPreviewMeshes = [];
+		this.toolManagerRef = null;
+		this.terrainBuilderRef = null;
+
+		// Call parent dispose method
+		super.dispose();
+	}
+}
+
+export default WallTool; 

--- a/src/js/tools/WallTool.js
+++ b/src/js/tools/WallTool.js
@@ -17,6 +17,7 @@ class WallTool extends BaseTool {
 
 		// CAREFUL: We need to explicitly get properties from the terrainBuilder
 		this.name = "WallTool";
+		this.tooltip = "Wall Tool: Click to start, click again to place. Use 1 | 2 to adjust height. Hold Ctrl to erase. Press Q to cancel. ";
 		this.wallHeight = 1;
 		this.isCtrlPressed = false;
 		this.wallStartPosition = null;
@@ -58,6 +59,7 @@ class WallTool extends BaseTool {
 			console.log('Initializing empty terrainRef.current in onActivate');
 			this.terrainRef.current = {};
 		}
+
 
 	}
 

--- a/src/js/tools/index.js
+++ b/src/js/tools/index.js
@@ -1,0 +1,12 @@
+/**
+ * Tools Module Index - Exports all tools and the tool manager
+ */
+import BaseTool from './BaseTool';
+import WallTool from './WallTool';
+import ToolManager from './ToolManager';
+
+export {
+  BaseTool,
+  WallTool,
+  ToolManager
+}; 


### PR DESCRIPTION
- Implemented WallTool extending BaseTool for wall placement and erasure functionality
- Added ToolManager to handle tool activation, deactivation, and event delegation
- Integrated WallTool into the editor with proper cleanup on deactivation
- Added support for tool-specific mouse and keyboard event handling
- Ensured proper tool state management and cleanup when switching tools

The Wall Tool allows users to place and erase walls in the editor, while the Tool Manager provides a centralized system for managing all editor tools.

1 and 2 control height
Hold Ctrl to erase
Q to cancel.

https://github.com/user-attachments/assets/ab6d8090-9f38-45c9-95a3-09003876dd7b



