### PR TITLE
Schematic Tab + Schematic Improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import TerrainBuilder, {
 import UndoRedoManager from "./js/managers/UndoRedoManager";
 import AIAssistantPanel from "./js/components/AIAssistantPanel";
 import BlockToolsSidebar, {
+    ActiveTabType,
     refreshBlockTools,
 } from "./js/components/BlockToolsSidebar";
 import DebugInfo from "./js/components/DebugInfo";
@@ -40,7 +41,7 @@ function App() {
     const [cameraReset, setCameraReset] = useState(false);
     const [cameraAngle, setCameraAngle] = useState(0);
     const [placementSize, setPlacementSize] = useState("single");
-    const [activeTab, setActiveTab] = useState("blocks");
+    const [activeTab, setActiveTab] = useState<ActiveTabType>("blocks");
     const [pageIsLoaded, setPageIsLoaded] = useState(false);
     const [scene, setScene] = useState(null);
     const [totalEnvironmentObjects, setTotalEnvironmentObjects] = useState(0);
@@ -189,7 +190,7 @@ function App() {
     const LoadingScreen = () => (
         <div className="loading-screen">
             <img
-                src={'/assets/img/hytopia_logo_white.png'}
+                src={"/assets/img/hytopia_logo_white.png"}
                 alt="Hytopia Logo"
                 className="loading-logo"
             />
@@ -330,7 +331,10 @@ function App() {
 
                 {/* Hytopia Logo */}
                 <div className="hytopia-logo-wrapper">
-                    <img src={'/assets/img/hytopia_logo_white.png'} alt="Hytopia Logo" />
+                    <img
+                        src={"/assets/img/hytopia_logo_white.png"}
+                        alt="Hytopia Logo"
+                    />
                     <p className="hytopia-version-text">
                         World Editor Version {version}
                     </p>
@@ -348,6 +352,7 @@ function App() {
                     onOpenTextureModal={() => setIsTextureModalOpen(true)}
                     terrainBuilderRef={terrainBuilderRef}
                     activeTab={activeTab}
+                    onLoadSchematicFromHistory={handleLoadAISchematic}
                     setActiveTab={setActiveTab}
                     setCurrentBlockType={setCurrentBlockType}
                     environmentBuilder={environmentBuilderRef.current}
@@ -477,8 +482,9 @@ function App() {
                         <Tooltip text={isMuted ? "Unmute" : "Mute"}>
                             <button
                                 onClick={toggleMute}
-                                className={`camera-control-button ${!isMuted ? "active" : ""
-                                    }`}
+                                className={`camera-control-button ${
+                                    !isMuted ? "active" : ""
+                                }`}
                             >
                                 <FaVolumeMute />
                             </button>

--- a/src/css/BlockToolsSidebar.css
+++ b/src/css/BlockToolsSidebar.css
@@ -142,53 +142,42 @@
   margin-bottom: 8px;
 }
 
-.tab-button-left {
-  height: 100%;
-  width: 50%;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 12px 0 0 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.1);
-  border-right-color: rgba(255, 255, 255, 0);
-  color: #fff;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: bold;
-  text-transform: uppercase;
+/* Generic Tab Button for three tabs */
+.tab-button {
+    flex: 1; /* Distribute space equally */
+    height: 100%;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1.5px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-weight: bold;
+    text-transform: uppercase;
+    background-color: transparent; /* Default state */
 }
 
-.tab-button-right {
-  height: 100%;
-  width: 50%;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 0 12px 12px 0;
-  border: 1.5px solid rgba(255, 255, 255, 0.1);
-  border-left-color: rgba(255, 255, 255, 0);
-  color: #fff;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: bold;
-  text-transform: uppercase;
+.tab-button:not(:last-child) {
+    border-right: none; /* Remove right border for buttons not at the end */
 }
 
-.tab-button-left:hover {
+.tab-button:first-child {
+    border-radius: 12px 0 0 12px;
+}
+
+.tab-button:last-child {
+    border-radius: 0 12px 12px 0;
+}
+
+/* Middle tab button needs no specific border radius if sides are handled */
+
+.tab-button:hover {
     background-color: rgba(80, 80, 80, 0.5);
 }
 
-.tab-button-left.active {
-    background-color: rgba(241, 241, 241, 0.2);
-}
-
-.tab-button-right:hover {
-    background-color: rgba(80, 80, 80, 0.5);
-}
-
-.tab-button-right.active {
+.tab-button.active {
     background-color: rgba(241, 241, 241, 0.2);
 }
 
@@ -609,4 +598,86 @@
   color: inherit;
   font-size: 1rem;
   padding: 4px;
+}
+
+/* Styles for Schematic Tab items */
+.schematic-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: 1px solid #555;
+  background-color: #3a3a3a;
+  cursor: pointer;
+  text-align: center;
+  min-height: 80px; /* Adjust for prompt visibility */
+  width: calc(33.333% - 4px); /* For 3 items per row, accounting for 6px gap (2 gaps for 3 items) */
+  box-sizing: border-box;
+  word-break: break-word;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: all 0.2s ease;
+  color: #ddd; /* Text color for prompt */
+}
+
+.schematic-button:hover {
+  background-color: #4a4a4a;
+  border-color: #777;
+  transform: translateY(-2px);
+}
+
+.schematic-button-icon {
+  margin-bottom: 8px; /* Increased space for prompt */
+}
+
+.schematic-button-icon img {
+  width: 32px; /* Or your preferred size */
+  height: 32px;
+  image-rendering: pixelated; /* Good for pixel art icons */
+  display: block;
+  margin: auto;
+}
+
+.schematic-button-prompt {
+  font-size: 0.75em; /* Slightly smaller prompt text */
+  line-height: 1.3;
+  max-height: 3.9em; /* Approx 3 lines of text (0.75 * 1.3 * 3) */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Forcing break-word can be aggressive, consider if needed based on actual prompts */
+  /* word-break: break-all; */ 
+}
+
+.no-schematics-text {
+    grid-column: 1 / -1; /* Span all columns in the grid */
+    text-align: center;
+    padding: 20px;
+    color: #888;
+    font-size: 13px;
+}
+
+.upload-icon {
+    width: 60px;
+    height: 60px;
+    margin-bottom: 10px;
+    filter: invert(75%) sepia(10%) saturate(500%) hue-rotate(170deg) brightness(90%) contrast(85%);
+}
+
+.schematic-loading-spinner {
+  width: 32px; /* Or adjust to your preference */
+  height: 32px; /* Or adjust to your preference */
+  border: 4px solid rgba(255, 255, 255, 0.2); /* Light trail */
+  border-top-color: #ffffff; /* Spinning part */
+  border-radius: 50%;
+  animation: schematic-spin 1s linear infinite;
+  display: inline-block; /* Helps it sit in the flow */
+  box-sizing: border-box;
+  margin: 8px; /* (48px container - 32px spinner) / 2 to center it like the image */
+}
+
+@keyframes schematic-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/css/BlockToolsSidebar.css
+++ b/src/css/BlockToolsSidebar.css
@@ -301,10 +301,11 @@
   margin-bottom: 10px;
 }
 
-.upload-icon,
+.block-tools-container .block-tools-sidebar .upload-icon,
 .block-icon {
-    width: 20px;
-    height: 20px;
+  color: #fff;
+  width: 20px;
+  height: 20px;
 }
 
 .texture-drop-zone.drag-over .upload-icon,

--- a/src/js/TerrainBuilder.js
+++ b/src/js/TerrainBuilder.js
@@ -705,6 +705,12 @@ function TerrainBuilder(
     const handleBlockPlacement = () => {
         console.log("********handleBlockPlacement********");
         console.log("currentBlockTypeRef.current", currentBlockTypeRef.current);
+
+        if (!currentBlockTypeRef.current) {
+            console.log("currentBlockTypeRef.current is undefined");
+            return;
+        }
+
         if (toolManagerRef.current && toolManagerRef.current.getActiveTool()) {
             return;
         }
@@ -803,7 +809,7 @@ function TerrainBuilder(
                         Object.keys(addedBlocks).length;
                     lastPlacementTimeRef.current = now;
                 }
-            } else if (modeRef.current === "remove") {
+            } else if (modeRef.current === "remove" && !currentBlockTypeRef?.current?.isEnvironment) {
                 const now = performance.now();
                 if (now - lastDeletionTimeRef.current < 50) {
                     return; // Exit if the delay hasn't passed

--- a/src/js/TerrainBuilder.js
+++ b/src/js/TerrainBuilder.js
@@ -756,7 +756,7 @@ function TerrainBuilder(
                 }
             }
         } else {
-            if (modeRef.current === "add" && !currentBlockTypeRef.current.isEnvironment) {
+            if (modeRef.current === "add" && !currentBlockTypeRef?.current?.isEnvironment) {
                 console.log("handleBlockPlacement - ADD");
                 const now = performance.now();
                 const positions = getPlacementPositions(

--- a/src/js/components/AIAssistantPanel.tsx
+++ b/src/js/components/AIAssistantPanel.tsx
@@ -1,6 +1,157 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import HCaptcha from "@hcaptcha/react-hcaptcha";
 import "../../css/AIAssistantPanel.css";
+
+// Helper to generate unique IDs
+const generateUniqueId = (): string => {
+    return Date.now().toString(36) + Math.random().toString(36).substring(2);
+};
+
+// Type for the raw schematic data from the backend (block coordinates to block ID)
+export type RawSchematicType = Record<string, number>;
+
+// Type for the value stored in IndexedDB against a unique ID
+export interface SchematicValue {
+    prompt: string;
+    schematic: RawSchematicType;
+    timestamp: number;
+}
+
+// Type for items in the generationHistory state, including their DB key as 'id'
+export interface SchematicHistoryEntry extends SchematicValue {
+    id: string;
+}
+
+const MIGRATION_MARKER_V2 = "schematicStoreMigrated_to_id_key_v2";
+
+async function migrateSchematicStoreV2IfNeeded(
+    db: IDBDatabase,
+    STORES: { SCHEMATICS: string }
+): Promise<void> {
+    if (localStorage.getItem(MIGRATION_MARKER_V2) === "true") {
+        console.log(
+            "[AI Panel] Schematic store (V2) already migrated or up-to-date."
+        );
+        return;
+    }
+
+    console.log("[AI Panel] Checking for V2 schematic store migration...");
+
+    // Wrap the transaction logic in a promise to await its completion
+    return new Promise(async (resolveMigration, rejectMigration) => {
+        const tx = db.transaction(STORES.SCHEMATICS, "readwrite");
+        const store = tx.objectStore(STORES.SCHEMATICS);
+        const itemsToMigrate: {
+            oldKey: string; // This was the prompt
+            valueToConvert: RawSchematicType & { timestamp?: number }; // Old schematic might have ad-hoc timestamp
+        }[] = [];
+        let migrationActuallyNeeded = false;
+
+        // Phase 1: Collect items to migrate (read-only part within the readwrite transaction)
+        const cursorRequest = store.openCursor();
+        await new Promise<void>((resolveCursor, rejectCursor) => {
+            cursorRequest.onsuccess = (event) => {
+                const cursor = (event.target as IDBRequest<IDBCursorWithValue>)
+                    .result;
+                if (cursor) {
+                    const val = cursor.value;
+                    if (
+                        typeof cursor.key === "string" &&
+                        typeof val === "object" &&
+                        val !== null &&
+                        val.prompt === undefined
+                    ) {
+                        migrationActuallyNeeded = true;
+                        itemsToMigrate.push({
+                            oldKey: cursor.key,
+                            valueToConvert: val as RawSchematicType & {
+                                timestamp?: number;
+                            },
+                        });
+                    }
+                    cursor.continue();
+                } else {
+                    resolveCursor(); // Cursor exhausted
+                }
+            };
+            cursorRequest.onerror = (event) => {
+                console.error(
+                    "[AI Panel] Error during V2 migration check (cursor phase):",
+                    (event.target as IDBRequest).error
+                );
+                rejectCursor((event.target as IDBRequest).error);
+            };
+        }).catch((error) => {
+            // If cursor phase fails, reject the main migration promise and don't proceed.
+            tx.abort(); // Abort the transaction
+            rejectMigration(error);
+            return; // Stop further execution in this path
+        });
+
+        // If cursor phase failed and rejected, the lines below won't run.
+
+        // Phase 2: Perform writes if needed
+        if (migrationActuallyNeeded && itemsToMigrate.length > 0) {
+            console.log(
+                `[AI Panel] Migrating ${itemsToMigrate.length} old V1 schematic entries to V2 format...`
+            );
+            for (const item of itemsToMigrate) {
+                const newId = generateUniqueId();
+                const oldSchematicData = item.valueToConvert;
+                const timestamp = oldSchematicData.timestamp || Date.now();
+                const cleanSchematic: RawSchematicType = {
+                    ...oldSchematicData,
+                };
+                if (cleanSchematic.timestamp !== undefined) {
+                    delete cleanSchematic.timestamp;
+                }
+                const newSchematicValue: SchematicValue = {
+                    prompt: item.oldKey,
+                    schematic: cleanSchematic,
+                    timestamp: timestamp,
+                };
+                try {
+                    store.delete(item.oldKey);
+                    store.add(newSchematicValue, newId);
+                } catch (e) {
+                    console.error(
+                        `[AI Panel] Error queueing migration operation for prompt "${item.oldKey}":`,
+                        e
+                    );
+                    // This error is for store operation call itself, not transaction error yet.
+                    // Depending on error, tx might already be unusable.
+                }
+            }
+            console.log(
+                "[AI Panel] V2 schematic store migration operations queued..."
+            );
+        } else {
+            console.log(
+                "[AI Panel] No V1 entries found requiring V2 migration."
+            );
+        }
+
+        tx.oncomplete = () => {
+            console.log(
+                "[AI Panel] V2 migration transaction completed successfully."
+            );
+            localStorage.setItem(MIGRATION_MARKER_V2, "true");
+            resolveMigration();
+        };
+
+        tx.onerror = (event) => {
+            console.error(
+                "[AI Panel] V2 migration transaction error:",
+                (event.target as IDBTransaction).error // tx.error can be used here
+            );
+            rejectMigration((event.target as IDBTransaction).error);
+        };
+
+        // If no migration operations were queued, and we reached here, the transaction will auto-commit (if no errors).
+        // If migration ops were queued, they will now execute.
+    });
+}
+
 const AIAssistantPanel = ({
     getAvailableBlocks,
     loadAISchematic,
@@ -8,74 +159,100 @@ const AIAssistantPanel = ({
 }) => {
     const [prompt, setPrompt] = useState("");
     const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState(null);
-    const [generationHistory, setGenerationHistory] = useState([]);
-    const [hCaptchaToken, setHCaptchaToken] = useState(null);
-    const [captchaError, setCaptchaError] = useState(null);
-    const hCaptchaRef = useRef(null);
+    const [error, setError] = useState<string | null>(null);
+    const [generationHistory, setGenerationHistory] = useState<
+        SchematicHistoryEntry[]
+    >([]);
+    const [hCaptchaToken, setHCaptchaToken] = useState<string | null>(null);
+    const [captchaError, setCaptchaError] = useState<string | null>(null);
+    const hCaptchaRef = useRef<HCaptcha>(null);
 
     useEffect(() => {
-        const loadSavedSchematics = async () => {
+        const loadAndMigrateSchematics = async () => {
             try {
                 const { DatabaseManager, STORES } = await import(
                     "../managers/DatabaseManager"
                 );
-
                 const db = await DatabaseManager.getDBConnection();
+
+                // Run migration if needed
+                await migrateSchematicStoreV2IfNeeded(db, STORES);
+
+                // Proceed with loading data (now expected to be in V2 format)
                 const tx = db.transaction(STORES.SCHEMATICS, "readonly");
                 const store = tx.objectStore(STORES.SCHEMATICS);
                 const cursorRequest = store.openCursor();
-                const loadedHistory = [];
+                const loadedHistory: SchematicHistoryEntry[] = [];
+
                 cursorRequest.onsuccess = (event) => {
-                    const cursor = event.target.result;
+                    const cursor = (
+                        event.target as IDBRequest<IDBCursorWithValue>
+                    ).result;
                     if (cursor) {
-                        loadedHistory.push({
-                            prompt: cursor.key,
-                            schematic: cursor.value,
-                        });
+                        const dbKey = cursor.key as string;
+                        const dbValue = cursor.value as SchematicValue;
+
+                        if (
+                            dbValue &&
+                            typeof dbValue.prompt === "string" &&
+                            dbValue.schematic &&
+                            typeof dbValue.timestamp === "number"
+                        ) {
+                            loadedHistory.push({
+                                id: dbKey,
+                                prompt: dbValue.prompt,
+                                schematic: dbValue.schematic,
+                                timestamp: dbValue.timestamp,
+                            });
+                        } else {
+                            console.warn(
+                                `[AI Panel] Skipping malformed V2 schematic entry (key: ${dbKey}):`,
+                                dbValue
+                            );
+                        }
                         cursor.continue();
                     } else {
                         if (loadedHistory.length > 0) {
                             loadedHistory.sort(
-                                (a, b) =>
-                                    (b.schematic.timestamp || 0) -
-                                    (a.schematic.timestamp || 0)
+                                (a, b) => b.timestamp - a.timestamp
                             );
                             setGenerationHistory(loadedHistory);
                             console.log(
-                                `[AI Panel] Loaded ${loadedHistory.length} saved schematics.`
+                                `[AI Panel] Loaded ${loadedHistory.length} V2 schematics.`
                             );
                         }
                     }
                 };
                 cursorRequest.onerror = (event) => {
                     console.error(
-                        "[AI Panel] Error reading schematics store with cursor:",
-                        event.target.error
+                        "[AI Panel] Error reading V2 schematics store:",
+                        (event.target as IDBRequest).error
                     );
                 };
             } catch (err) {
                 console.error(
-                    "[AI Panel] Error loading saved schematics:",
+                    "[AI Panel] Error loading/migrating schematics:",
                     err
                 );
             }
         };
         if (isVisible) {
-            loadSavedSchematics();
+            loadAndMigrateSchematics();
         }
-    }, [isVisible]); // Re-load if visibility changes
+    }, [isVisible]);
 
     const handleGenerate = useCallback(async () => {
         if (!prompt.trim() || isLoading) return;
         setIsLoading(true);
         setError(null);
         setCaptchaError(null);
+
         if (!hCaptchaToken) {
             setCaptchaError("Please complete the CAPTCHA verification.");
             setIsLoading(false);
             return;
         }
+
         try {
             const availableBlocks = await getAvailableBlocks();
             if (!availableBlocks || availableBlocks.length === 0) {
@@ -95,44 +272,59 @@ const AIAssistantPanel = ({
                     }),
                 }
             );
+
             if (!response.ok) {
                 const errorData = await response.json();
                 throw new Error(
                     errorData.error || "Failed to generate building"
                 );
             }
-            const schematic = await response.json();
-            if (schematic && Object.keys(schematic).length > 0) {
-                const newHistoryEntry = { prompt, schematic };
+
+            const schematicData: RawSchematicType = await response.json();
+            if (schematicData && Object.keys(schematicData).length > 0) {
+                const newId = generateUniqueId();
+                const newSchematicValue: SchematicValue = {
+                    prompt,
+                    schematic: schematicData,
+                    timestamp: Date.now(),
+                };
+
+                const newHistoryEntry: SchematicHistoryEntry = {
+                    id: newId,
+                    ...newSchematicValue,
+                };
+
                 setGenerationHistory((prevHistory) => [
                     newHistoryEntry,
                     ...prevHistory,
                 ]);
-                loadAISchematic(schematic);
+                loadAISchematic(schematicData); // loadAISchematic expects the raw schematic
 
                 try {
                     const { DatabaseManager, STORES } = await import(
                         "../managers/DatabaseManager"
                     );
-
                     await DatabaseManager.saveData(
                         STORES.SCHEMATICS,
-                        prompt,
-                        schematic
+                        newId, // Unique ID as key
+                        newSchematicValue // The object { prompt, schematic, timestamp } as value
                     );
                     console.log(
-                        `[AI Panel] Saved schematic for prompt: "${prompt}"`
+                        `[AI Panel] Saved V2 schematic with ID: "${newId}" for prompt: "${prompt}"`
                     );
+                    window.dispatchEvent(
+                        new CustomEvent("schematicsDbUpdated")
+                    ); // Notify sidebar
                 } catch (dbError) {
                     console.error(
-                        "[AI Panel] Error saving schematic to DB:",
+                        "[AI Panel] Error saving V2 schematic to DB:",
                         dbError
                     );
                 }
             } else {
                 setError("AI could not generate a structure for this prompt.");
             }
-        } catch (err) {
+        } catch (err: any) {
             console.error("Error generating AI structure:", err);
             setError(err.message || "An unexpected error occurred.");
         } finally {
@@ -143,9 +335,11 @@ const AIAssistantPanel = ({
             }
         }
     }, [prompt, isLoading, getAvailableBlocks, loadAISchematic, hCaptchaToken]);
+
     if (!isVisible) {
         return null;
     }
+
     return (
         <div className="ai-assistant-panel">
             <h4>AI Building Assistant</h4>
@@ -164,11 +358,12 @@ const AIAssistantPanel = ({
                 {isLoading ? "Generating..." : "Generate Structure"}
             </button>
             {error && <div className="ai-assistant-error">{error}</div>}
-            {/* Added HCaptcha Component - Wrapped for styling */}
-            {/* <div className="ai-assistant-captcha-container"> */}
             <HCaptcha
                 ref={hCaptchaRef}
-                sitekey={process.env.REACT_APP_HCAPTCHA_SITE_KEY}
+                sitekey={
+                    process.env.REACT_APP_HCAPTCHA_SITE_KEY ||
+                    "10000000-ffff-ffff-ffff-000000000001"
+                } // Fallback for local dev if .env is missing
                 size="compact"
                 theme="dark"
                 onVerify={(token) => {
@@ -184,22 +379,20 @@ const AIAssistantPanel = ({
                     setCaptchaError(`CAPTCHA error: ${err}`);
                 }}
             />
-            {/* </div> */}
             {captchaError && (
                 <div className="ai-assistant-error">{captchaError}</div>
             )}
-            {/* Added History Section */}
             {generationHistory.length > 0 && (
                 <div
                     onWheel={(e) => {
-                        e.stopPropagation();
+                        e.stopPropagation(); // Prevent page scroll while scrolling history
                     }}
                     className="ai-assistant-history-list"
                 >
                     <h5>History:</h5>
-                    {generationHistory.map((entry, index) => (
+                    {generationHistory.map((entry) => (
                         <div
-                            key={index}
+                            key={entry.id} // Use unique ID for key
                             className="ai-assistant-history-item"
                             onClick={() => loadAISchematic(entry.schematic)}
                             title={`Load: ${entry.prompt}`}

--- a/src/js/components/AIAssistantPanel.tsx
+++ b/src/js/components/AIAssistantPanel.tsx
@@ -3,7 +3,7 @@ import HCaptcha from "@hcaptcha/react-hcaptcha";
 import "../../css/AIAssistantPanel.css";
 
 // Helper to generate unique IDs
-const generateUniqueId = (): string => {
+export const generateUniqueId = (): string => {
     return Date.now().toString(36) + Math.random().toString(36).substring(2);
 };
 

--- a/src/js/components/BlockToolsSidebar.js
+++ b/src/js/components/BlockToolsSidebar.js
@@ -1,7 +1,7 @@
 import { saveAs } from "file-saver";
 import JSZip from "jszip";
-import { useEffect, useState } from "react";
-import { FaDownload } from "react-icons/fa";
+import { useEffect, useState, useCallback } from "react";
+import { FaDownload, FaWrench } from "react-icons/fa";
 import "../../css/BlockToolsSidebar.css";
 import { environmentModels } from "../EnvironmentBuilder";
 import {
@@ -9,9 +9,10 @@ import {
     blockTypes,
     getCustomBlocks,
     processCustomBlock,
-    removeCustomBlock
+    removeCustomBlock,
 } from "../managers/BlockTypesManager";
 import { DatabaseManager, STORES } from "../managers/DatabaseManager";
+import { generateSchematicPreview } from "../utils/SchematicPreviewRenderer";
 import BlockButton from "./BlockButton";
 import EnvironmentButton from "./EnvironmentButton";
 import ModelPreview from "./ModelPreview";
@@ -59,14 +60,28 @@ const createPlaceholderBlob = () => {
         ctx.fillStyle = "#FF00FF"; // Magenta
         ctx.fillRect(0, 0, 16, 16);
 
-
-
         return new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
     }
     return Promise.resolve(null); // Fallback
 };
 const firstDefaultModel = environmentModels.find((m) => !m.isCustom);
 const initialPreviewUrl = firstDefaultModel?.modelUrl ?? null;
+
+/**
+ * @typedef {"blocks" | "environment" | "schematics"} ActiveTabType
+ */
+
+/**
+ * @param {object} props
+ * @param {ActiveTabType} props.activeTab
+ * @param {React.RefObject<any>} props.terrainBuilderRef
+ * @param {(tab: ActiveTabType) => void} props.setActiveTab
+ * @param {(block: any | null) => void} props.setCurrentBlockType
+ * @param {React.RefObject<any>} props.environmentBuilder
+ * @param {(settings: any) => void} [props.onPlacementSettingsChange]
+ * @param {() => void} props.onOpenTextureModal
+ * @param {(schematic: import("./AIAssistantPanel").RawSchematicType) => void} props.onLoadSchematicFromHistory
+ */
 const BlockToolsSidebar = ({
     activeTab,
     terrainBuilderRef,
@@ -75,6 +90,7 @@ const BlockToolsSidebar = ({
     environmentBuilder,
     onPlacementSettingsChange,
     onOpenTextureModal,
+    onLoadSchematicFromHistory,
 }) => {
     const [settings, setSettings] = useState({
         randomScale: false,
@@ -88,17 +104,96 @@ const BlockToolsSidebar = ({
     });
     const [customBlocks, setCustomBlocks] = useState([]);
     const [previewModelUrl, setPreviewModelUrl] = useState(initialPreviewUrl);
+    /** @type {[import("./AIAssistantPanel").SchematicHistoryEntry[], Function]} */
+    const [schematicList, setSchematicList] = useState([]);
+    const [schematicPreviews, setSchematicPreviews] = useState({});
+
+    const loadSchematicsFromDB = useCallback(async () => {
+        console.log("[BlockToolsSidebar] Loading schematics from DB...");
+        try {
+            const { DatabaseManager, STORES } = await import(
+                "../managers/DatabaseManager"
+            );
+            const db = await DatabaseManager.getDBConnection();
+            const tx = db.transaction(STORES.SCHEMATICS, "readonly");
+            const store = tx.objectStore(STORES.SCHEMATICS);
+            const cursorRequest = store.openCursor();
+            /** @type {import("./AIAssistantPanel").SchematicHistoryEntry[]} */
+            const loadedSchematics = [];
+
+            cursorRequest.onsuccess = (event) => {
+                const cursor = event.target.result;
+                if (cursor) {
+                    const dbKey = cursor.key;
+                    const dbValue = cursor.value;
+                    // Basic check for V2 schematic structure
+                    if (
+                        dbValue &&
+                        typeof dbValue.prompt === "string" &&
+                        dbValue.schematic &&
+                        typeof dbValue.timestamp === "number"
+                    ) {
+                        loadedSchematics.push({
+                            id: dbKey,
+                            prompt: dbValue.prompt,
+                            schematic: dbValue.schematic,
+                            timestamp: dbValue.timestamp,
+                        });
+                    }
+                    cursor.continue();
+                } else {
+                    loadedSchematics.sort((a, b) => b.timestamp - a.timestamp);
+                    setSchematicList(loadedSchematics);
+                    console.log(
+                        `[BlockToolsSidebar] Loaded ${loadedSchematics.length} schematics.`
+                    );
+                }
+            };
+            cursorRequest.onerror = (event) => {
+                console.error(
+                    "[BlockToolsSidebar] Error reading schematics store:",
+                    event.target.error
+                );
+            };
+        } catch (err) {
+            console.error(
+                "[BlockToolsSidebar] Error accessing DB for schematics:",
+                err
+            );
+        }
+    }, []);
 
     useEffect(() => {
+        if (activeTab === "schematics") {
+            loadSchematicsFromDB();
+        }
+        const handleSchematicsUpdated = () => {
+            console.log(
+                "[BlockToolsSidebar] schematicsDbUpdated event received."
+            );
+            if (
+                document.visibilityState === "visible" &&
+                activeTab === "schematics"
+            ) {
+                loadSchematicsFromDB();
+            }
+        };
+        window.addEventListener("schematicsDbUpdated", handleSchematicsUpdated);
 
+        return () => {
+            window.removeEventListener(
+                "schematicsDbUpdated",
+                handleSchematicsUpdated
+            );
+        };
+    }, [activeTab, loadSchematicsFromDB]);
+
+    useEffect(() => {
         if (activeTab === "environment" && initialPreviewUrl) {
             const model = environmentModels.find(
                 (m) => m.modelUrl === initialPreviewUrl
             );
             if (model) {
-
-
-
                 selectedBlockID = model.id;
                 setCurrentBlockType({
                     ...model,
@@ -108,13 +203,10 @@ const BlockToolsSidebar = ({
                     "Initial environment model auto-selected:",
                     model.name
                 );
-
-
             }
         }
+    }, []);
 
-
-    }, []); // Run once on mount
     useEffect(() => {
         const handleRefresh = () => {
             console.log("Handling refresh event in BlockToolsSidebar");
@@ -154,12 +246,67 @@ const BlockToolsSidebar = ({
             window.removeEventListener("textureAtlasUpdated", handleRefresh);
         };
     }, []);
+
+    useEffect(() => {
+        // Generate previews when schematicList changes
+        const generatePreviews = async () => {
+            if (schematicList.length > 0) {
+                const newPreviews = { ...schematicPreviews };
+                let updateNeeded = false;
+                for (const entry of schematicList) {
+                    if (!newPreviews[entry.id] && entry.schematic) {
+                        try {
+                            console.log(
+                                `[BlockToolsSidebar] Generating preview for schematic: ${entry.prompt.substring(
+                                    0,
+                                    30
+                                )}...`
+                            );
+                            const dataUrl = await generateSchematicPreview(
+                                entry.schematic,
+                                {
+                                    width: 48,
+                                    height: 48,
+                                    background: "transparent",
+                                }
+                            );
+                            if (dataUrl) {
+                                newPreviews[entry.id] = dataUrl;
+                                updateNeeded = true;
+                            } else {
+                                console.warn(
+                                    `[BlockToolsSidebar] Preview generation returned empty for ${entry.id}`
+                                );
+                                newPreviews[entry.id] = null; // Mark as attempted but failed
+                                updateNeeded = true;
+                            }
+                        } catch (error) {
+                            console.error(
+                                `[BlockToolsSidebar] Error generating preview for schematic ${entry.id}:`,
+                                error
+                            );
+                            newPreviews[entry.id] = null; // Mark as attempted but failed
+                            updateNeeded = true;
+                        }
+                    }
+                }
+                if (updateNeeded) {
+                    console.log(
+                        "[BlockToolsSidebar] Updating schematic previews state."
+                    );
+                    setSchematicPreviews(newPreviews);
+                }
+            }
+        };
+        generatePreviews();
+    }, [schematicList]); // Removed schematicPreviews from dependency array to avoid potential loop
+
     const updateSettings = (updates) => {
         const newSettings = { ...settings, ...updates };
         setSettings(newSettings);
-
         onPlacementSettingsChange?.(newSettings);
     };
+
     const handleDragStart = (blockId) => {
         console.log("Drag started with block:", blockId);
     };
@@ -224,8 +371,8 @@ const BlockToolsSidebar = ({
         }
     };
 
+    /** @param {ActiveTabType} newTab */
     const handleTabChange = (newTab) => {
-
         if (newTab === "blocks") {
             setCurrentBlockType(blockTypes[0]);
             setPreviewModelUrl(null);
@@ -239,17 +386,19 @@ const BlockToolsSidebar = ({
                 setCurrentBlockType(null);
                 setPreviewModelUrl(null);
             }
+        } else if (newTab === "schematics") {
+            setPreviewModelUrl(null);
+            setCurrentBlockType(null);
+            loadSchematicsFromDB();
         }
         setActiveTab(newTab);
     };
+
     const handleDeleteCustomBlock = async (blockType) => {
         const confirmMessage = `Deleting "${blockType.name}" will replace any instances of this block with an error texture. Are you sure you want to proceed?`;
         if (window.confirm(confirmMessage)) {
-
             removeCustomBlock(blockType.id);
-
             setCustomBlocks(getCustomBlocks());
-
             try {
                 await DatabaseManager.saveData(
                     STORES.CUSTOM_BLOCKS,
@@ -263,33 +412,32 @@ const BlockToolsSidebar = ({
                 );
             }
             try {
-
                 const currentTerrain =
                     (await DatabaseManager.getData(
                         STORES.TERRAIN,
                         "current"
                     )) || {};
                 const newTerrain = { ...currentTerrain };
-
                 const errorBlock = {
-                    id: 999, // Special ID for error blocks
+                    id: 999,
                     name: `missing_${blockType.name}`,
                     textureUri: "./assets/blocks/error.png",
                     hasMissingTexture: true,
-                    originalId: blockType.id, // Store the original ID for potential future recovery
+                    originalId: blockType.id,
                 };
-
                 const errorId = errorBlock.id;
-
-                console.log('blockType', blockType)
+                console.log("blockType", blockType);
                 Object.entries(newTerrain).forEach(([position, block]) => {
-                    console.log('block', block)
-                    console.log('blockType.id == block.id', blockType.id == block.id)
+                    console.log("block", block);
+                    console.log(
+                        "blockType.id == block.id",
+                        blockType.id == block.id
+                    );
                     if (block === blockType.id) {
                         newTerrain[position] = errorId;
                     }
                 });
-                console.log('newTerrain', newTerrain)
+                console.log("newTerrain", newTerrain);
                 await DatabaseManager.saveData(
                     STORES.TERRAIN,
                     "current",
@@ -302,10 +450,10 @@ const BlockToolsSidebar = ({
                     error
                 );
             }
-
             refreshBlockTools();
         }
     };
+
     const handleDeleteEnvironmentModel = async (modelId) => {
         if (
             window.confirm("Are you sure you want to delete this custom model?")
@@ -320,14 +468,12 @@ const BlockToolsSidebar = ({
                     (model) => model.id === modelId
                 );
                 if (!modelToDelete) return;
-
                 const modelIndex = environmentModels.findIndex(
                     (model) => model.id === modelId
                 );
                 if (modelIndex !== -1) {
                     environmentModels.splice(modelIndex, 1);
                 }
-
                 const updatedModels = existingModels.filter(
                     (model) => model.name !== modelToDelete.name
                 );
@@ -336,7 +482,6 @@ const BlockToolsSidebar = ({
                     "models",
                     updatedModels
                 );
-
                 const currentEnvironment =
                     (await DatabaseManager.getData(
                         STORES.ENVIRONMENT,
@@ -345,13 +490,11 @@ const BlockToolsSidebar = ({
                 const updatedEnvironment = currentEnvironment.filter(
                     (obj) => obj.name !== modelToDelete.name
                 );
-
                 await DatabaseManager.saveData(
                     STORES.ENVIRONMENT,
                     "current",
                     updatedEnvironment
                 );
-
                 if (environmentBuilder && environmentBuilder.current) {
                     await environmentBuilder.current.refreshEnvironmentFromDB();
                 }
@@ -366,6 +509,7 @@ const BlockToolsSidebar = ({
             }
         }
     };
+
     const handleEnvironmentSelect = (envType) => {
         console.log("Environment selected:", envType);
         setCurrentBlockType({
@@ -375,30 +519,32 @@ const BlockToolsSidebar = ({
         selectedBlockID = envType.id;
         setPreviewModelUrl(envType.modelUrl);
     };
-    const handleBlockSelect = (blockType) => {
 
+    const handleBlockSelect = (blockType) => {
         setCurrentBlockType({
             ...blockType,
             isEnvironment: false,
         });
         selectedBlockID = blockType.id;
     };
+
+    /** @param {import("./AIAssistantPanel").SchematicHistoryEntry} schematicEntry */
+    const handleSchematicSelect = (schematicEntry) => {
+        console.log("Schematic selected:", schematicEntry.prompt);
+        onLoadSchematicFromHistory(schematicEntry.schematic);
+    };
+
     const handleCustomAssetDropUpload = async (e) => {
         e.preventDefault();
         e.currentTarget.classList.remove("drag-over");
         const files = Array.from(e.dataTransfer.files);
-
         if (activeTab === "blocks") {
             const imageFiles = files.filter((file) =>
                 file.type.startsWith("image/")
             );
-
             if (imageFiles.length > 0) {
-
                 if (imageFiles.length > 1) {
-
                     try {
-
                         const blockPromises = imageFiles.map((file) => {
                             return new Promise((resolve) => {
                                 const reader = new FileReader();
@@ -406,7 +552,7 @@ const BlockToolsSidebar = ({
                                     const blockName = file.name.replace(
                                         /\.[^/.]+$/,
                                         ""
-                                    ); // Remove file extension
+                                    );
                                     resolve({
                                         name: blockName,
                                         textureUri: reader.result,
@@ -415,18 +561,14 @@ const BlockToolsSidebar = ({
                                 reader.readAsDataURL(file);
                             });
                         });
-
                         const blocks = await Promise.all(blockPromises);
-
                         await batchProcessCustomBlocks(blocks);
-
                         const updatedCustomBlocks = getCustomBlocks();
                         await DatabaseManager.saveData(
                             STORES.CUSTOM_BLOCKS,
                             "blocks",
                             updatedCustomBlocks
                         );
-
                         refreshBlockTools();
                     } catch (error) {
                         console.error(
@@ -435,7 +577,6 @@ const BlockToolsSidebar = ({
                         );
                     }
                 } else {
-
                     const filePromises = imageFiles.map((file) => {
                         return new Promise((resolve) => {
                             const reader = new FileReader();
@@ -443,21 +584,18 @@ const BlockToolsSidebar = ({
                                 const blockName = file.name.replace(
                                     /\.[^/.]+$/,
                                     ""
-                                ); // Remove file extension
+                                );
                                 const block = {
                                     name: blockName,
                                     textureUri: reader.result,
                                 };
-
                                 processCustomBlock(block);
                                 resolve();
                             };
                             reader.readAsDataURL(file);
                         });
                     });
-
                     await Promise.all(filePromises);
-
                     try {
                         const updatedCustomBlocks = getCustomBlocks();
                         await DatabaseManager.saveData(
@@ -471,18 +609,14 @@ const BlockToolsSidebar = ({
                             error
                         );
                     }
-
                     refreshBlockTools();
                 }
             }
-        }
-
-        else if (activeTab === "environment") {
+        } else if (activeTab === "environment") {
             const modelFiles = files.filter(
                 (file) =>
                     file.name.endsWith(".gltf") || file.name.endsWith(".glb")
             );
-
             if (modelFiles.length > 0) {
                 const existingModels =
                     (await DatabaseManager.getData(
@@ -495,20 +629,17 @@ const BlockToolsSidebar = ({
                 const newModelsForDB = [];
                 const newModelsForUI = [];
                 const duplicateFileNames = new Set();
-                const processedFileNames = new Set(); // Track names within the current batch
-
-
+                const processedFileNames = new Set();
                 const fileReadPromises = modelFiles.map((file) => {
                     return new Promise((resolve, reject) => {
                         const fileName = file.name.replace(/\.[^/.]+$/, "");
                         const lowerCaseFileName = fileName.toLowerCase();
-
                         if (existingModelNames.has(lowerCaseFileName)) {
                             duplicateFileNames.add(fileName);
                             console.warn(
                                 `Duplicate model skipped: ${fileName} (already exists)`
                             );
-                            reject(new Error(`Duplicate model: ${fileName}`)); // Reject to skip processing
+                            reject(new Error(`Duplicate model: ${fileName}`));
                             return;
                         }
                         if (processedFileNames.has(lowerCaseFileName)) {
@@ -520,11 +651,10 @@ const BlockToolsSidebar = ({
                                 new Error(
                                     `Duplicate model in batch: ${fileName}`
                                 )
-                            ); // Reject to skip processing
+                            );
                             return;
                         }
-                        processedFileNames.add(lowerCaseFileName); // Add to batch tracking
-
+                        processedFileNames.add(lowerCaseFileName);
                         const reader = new FileReader();
                         reader.onload = () =>
                             resolve({ file, fileName, data: reader.result });
@@ -532,11 +662,7 @@ const BlockToolsSidebar = ({
                         reader.readAsArrayBuffer(file);
                     });
                 });
-
-
                 const results = await Promise.allSettled(fileReadPromises);
-
-
                 if (duplicateFileNames.size > 0) {
                     alert(
                         `The following model names already exist or were duplicated in the drop:\n- ${Array.from(
@@ -546,42 +672,36 @@ const BlockToolsSidebar = ({
                         )}\n\nPlease rename the files and try again.`
                     );
                 }
-
-
                 results.forEach((result) => {
                     if (result.status === "fulfilled") {
                         const { file, fileName, data } = result.value;
-
                         try {
-
                             const modelDataForDB = {
                                 name: fileName,
-                                data: data, // Store ArrayBuffer
+                                data: data,
                                 timestamp: Date.now(),
                             };
                             newModelsForDB.push(modelDataForDB);
-
-
                             const blob = new Blob([data], {
                                 type: file.type || "model/gltf-binary",
-                            }); // Use file.type or default for glb
+                            });
                             const fileUrl = URL.createObjectURL(blob);
                             const newEnvironmentModel = {
                                 id:
                                     Math.max(
-                                        0, // Start from 0 if no custom models exist yet
+                                        0,
                                         ...environmentModels
                                             .filter((model) => model.isCustom)
                                             .map((model) => model.id),
-                                        299 // Ensure IDs start after default range
+                                        299
                                     ) +
                                     1 +
-                                    newModelsForUI.length, // Increment ID based on successful additions
+                                    newModelsForUI.length,
                                 name: fileName,
                                 modelUrl: fileUrl,
                                 isEnvironment: true,
                                 isCustom: true,
-                                animations: ["idle"], // Default animation assumption
+                                animations: ["idle"],
                             };
                             newModelsForUI.push(newEnvironmentModel);
                         } catch (error) {
@@ -589,26 +709,20 @@ const BlockToolsSidebar = ({
                                 `Error processing model ${fileName}:`,
                                 error
                             );
-
                         }
                     } else {
-
                         console.error(
                             "Failed to process a model file:",
                             result.reason?.message || result.reason
                         );
                     }
                 });
-
-
                 if (newModelsForDB.length > 0) {
                     try {
-
                         const updatedModelsForDB = [
                             ...existingModels,
                             ...newModelsForDB,
                         ];
-
                         await DatabaseManager.saveData(
                             STORES.CUSTOM_MODELS,
                             "models",
@@ -617,11 +731,7 @@ const BlockToolsSidebar = ({
                         console.log(
                             `Saved ${newModelsForDB.length} new models to DB.`
                         );
-
-
                         environmentModels.push(...newModelsForUI);
-
-
                         if (environmentBuilder && environmentBuilder.current) {
                             for (const model of newModelsForUI) {
                                 try {
@@ -639,8 +749,6 @@ const BlockToolsSidebar = ({
                                 }
                             }
                         }
-
-
                         refreshBlockTools();
                     } catch (error) {
                         console.error(
@@ -650,13 +758,11 @@ const BlockToolsSidebar = ({
                         alert(
                             "An error occurred while saving or loading the new models. Check the console for details."
                         );
-
                     }
                 } else if (
                     duplicateFileNames.size === 0 &&
                     modelFiles.length > 0
                 ) {
-
                     alert(
                         "Could not process any of the dropped model files. Check the console for errors."
                     );
@@ -664,13 +770,14 @@ const BlockToolsSidebar = ({
             }
         }
     };
+
     return (
         <div className="block-tools-container">
             <div className="dead-space"></div>
             <div className="block-tools-sidebar">
                 <div className="tab-button-wrapper">
                     <button
-                        className={`tab-button-left ${
+                        className={`tab-button ${
                             activeTab === "blocks" ? "active" : ""
                         }`}
                         onClick={() => handleTabChange("blocks")}
@@ -678,12 +785,20 @@ const BlockToolsSidebar = ({
                         Blocks
                     </button>
                     <button
-                        className={`tab-button-right ${
+                        className={`tab-button ${
                             activeTab === "environment" ? "active" : ""
                         }`}
                         onClick={() => handleTabChange("environment")}
                     >
                         Models
+                    </button>
+                    <button
+                        className={`tab-button ${
+                            activeTab === "schematics" ? "active" : ""
+                        }`}
+                        onClick={() => handleTabChange("schematics")}
+                    >
+                        Schematics
                     </button>
                 </div>
                 <div className="block-buttons-grid">
@@ -748,7 +863,7 @@ const BlockToolsSidebar = ({
                                     />
                                 ))}
                         </>
-                    ) : (
+                    ) : activeTab === "environment" ? (
                         <>
                             <div className="environment-preview-container">
                                 {previewModelUrl ? (
@@ -814,7 +929,58 @@ const BlockToolsSidebar = ({
                                     ))}
                             </div>
                         </>
-                    )}
+                    ) : activeTab === "schematics" ? (
+                        <>
+                            <div className="block-tools-section-label">
+                                Saved Schematics
+                            </div>
+                            {schematicList.length === 0 && (
+                                <div className="no-schematics-text">
+                                    No schematics saved yet. Generate some using
+                                    the AI Assistant!
+                                </div>
+                            )}
+                            {schematicList.map((entry) => (
+                                <div
+                                    key={entry.id}
+                                    className="schematic-button"
+                                    onClick={() => handleSchematicSelect(entry)}
+                                    title={`Load: ${entry.prompt}`}
+                                >
+                                    <div className="schematic-button-icon">
+                                        {typeof schematicPreviews[entry.id] ===
+                                        "string" ? (
+                                            <img
+                                                src={
+                                                    schematicPreviews[entry.id]
+                                                }
+                                                alt="Schematic preview"
+                                                style={{
+                                                    width: "48px",
+                                                    height: "48px",
+                                                    objectFit: "contain",
+                                                }}
+                                            />
+                                        ) : schematicPreviews[entry.id] ===
+                                          null ? (
+                                            <FaWrench title="Preview unavailable" />
+                                        ) : (
+                                            <div
+                                                className="schematic-loading-spinner"
+                                                title="Loading preview..."
+                                            ></div>
+                                        )}
+                                    </div>
+                                    <div className="schematic-button-prompt">
+                                        {entry.prompt.length > 50
+                                            ? entry.prompt.substring(0, 47) +
+                                              "..."
+                                            : entry.prompt}
+                                    </div>
+                                </div>
+                            ))}
+                        </>
+                    ) : null}
                 </div>
                 {activeTab === "environment" && (
                     <div className="placement-tools">
@@ -1148,11 +1314,12 @@ const BlockToolsSidebar = ({
                         <div className="drop-zone-text">
                             {activeTab === "blocks"
                                 ? "Drag textures here to add new blocks or fix missing textures"
-                                : "Drag .gltf files here to add custom models"}
+                                : activeTab === "environment"
+                                ? "Drag .gltf files here to add custom models"
+                                : "Use AI Assistant to generate schematics"}
                         </div>
                     </div>
                 </div>
-                {/* Create Texture Button - Added Here */}
                 <button
                     className="create-texture-button"
                     onClick={onOpenTextureModal}

--- a/src/js/utils/SchematicPreviewRenderer.ts
+++ b/src/js/utils/SchematicPreviewRenderer.ts
@@ -1,0 +1,381 @@
+/**
+ * SchematicPreviewRenderer
+ * -----------------------
+ * A tiny helper that turns the raw schematic data structure used by the
+ * SchematicPlacementTool into a small isometric preview image that can be
+ * dropped straight into an <img> tag.
+ *
+ * Usage example (inside a React component):
+ *
+ *   import { generateSchematicPreview } from "../utils/SchematicPreviewRenderer";
+ *   const dataUrl = await generateSchematicPreview(schematicData, { width: 96, height: 96 });
+ *   <img src={dataUrl} />
+ *
+ * The function purposefully keeps all heavy lifting (THREE.Scene, geometry, etc.)
+ * completely self-contained so that nothing is leaked into the rest of the
+ * application.  Every call builds a throw-away scene, renders once to an
+ * off-screen WebGL canvas and immediately disposes all THREE resources so that
+ * we don't leave GPU memory lying around.
+ */
+
+import * as THREE from "three";
+import BlockTypeRegistryModule from "../blocks/BlockTypeRegistry";
+
+interface BlockFaceTextures {
+    right?: string;
+    left?: string;
+    top?: string;
+    bottom?: string;
+    front?: string;
+    back?: string;
+    all?: string; // Catch-all for simple block types
+    default?: string; // Fallback texture
+    [key: string]: string | undefined;
+}
+
+interface BlockType {
+    textureUris?: BlockFaceTextures;
+}
+
+interface BlockTypeRegistryInstance {
+    getBlockType: (blockId: number) => BlockType | undefined | null;
+    initialize: () => Promise<void>;
+}
+
+const BlockTypeRegistry: { instance?: BlockTypeRegistryInstance } | null =
+    BlockTypeRegistryModule || null;
+
+// A tiny, global texture cache so we don't reload the exact same PNG dozens of
+// times when the preview contains many instances of the same block type.
+const _textureLoader = new THREE.TextureLoader();
+const _textureCache = new Map<string, Promise<THREE.Texture | null>>();
+
+function _loadTexture(
+    path: string | undefined | null
+): Promise<THREE.Texture | null> {
+    if (!path) return Promise.resolve(null);
+
+    // Re-use in-flight / finished loads to avoid duplicate requests.
+    if (_textureCache.has(path)) return _textureCache.get(path)!; // Non-null assertion as we check with .has()
+
+    const p = new Promise<THREE.Texture | null>((resolve) => {
+        _textureLoader.load(
+            path,
+            (texture: THREE.Texture) => {
+                texture.minFilter = THREE.LinearMipMapLinearFilter;
+                texture.magFilter = THREE.NearestFilter;
+                resolve(texture);
+            },
+            undefined, // onProgress callback, not used
+            () => {
+                // onError callback
+                console.warn(
+                    `SchematicPreviewRenderer – failed to load texture ${path}. Falling back to colour.`
+                );
+                resolve(null);
+            }
+        );
+    });
+    _textureCache.set(path, p);
+    return p;
+}
+
+/**
+ * Derive a reasonably unique, pleasant colour for a given numeric block id.
+ * The returned value is a hexadecimal number accepted by THREE.Color.
+ */
+function colourFromBlockId(blockId: number): number {
+    // Knuth multiplicative hash – gives us a well-distributed pseudo-random
+    // integer in the 0 ... 2^32 range that we can trim down to 24-bit rgb.
+    const hashed = (blockId * 2654435761) >>> 0;
+    return hashed & 0xffffff; // keep lower 24 bits
+}
+
+interface FacePaths {
+    right: string | null;
+    left: string | null;
+    top: string | null;
+    bottom: string | null;
+    front: string | null;
+    back: string | null;
+}
+
+/**
+ * Attempt to resolve file paths for each box face texture for the given block
+ * id using BlockTypeRegistry (if available).
+ */
+function _getFaceTexturePaths(blockId: number): FacePaths | null {
+    if (!BlockTypeRegistry?.instance) return null;
+
+    try {
+        const blockType = BlockTypeRegistry.instance.getBlockType?.(blockId);
+        if (!blockType) return null;
+
+        const textureUris = blockType.textureUris || {};
+
+        const _pick = (
+            ...candidates: (string | undefined | null)[]
+        ): string | null => {
+            for (const c of candidates) {
+                if (c) return c;
+            }
+            return null;
+        };
+
+        return {
+            right: _pick(
+                textureUris.right,
+                textureUris.all,
+                textureUris.default
+            ),
+            left: _pick(textureUris.left, textureUris.all, textureUris.default),
+            top: _pick(textureUris.top, textureUris.all, textureUris.default),
+            bottom: _pick(
+                textureUris.bottom,
+                textureUris.all,
+                textureUris.default
+            ),
+            front: _pick(
+                textureUris.front,
+                textureUris.all,
+                textureUris.default
+            ),
+            back: _pick(textureUris.back, textureUris.all, textureUris.default),
+        };
+    } catch (err) {
+        console.warn(
+            `SchematicPreviewRenderer – error while resolving texture paths for block ${blockId}:`,
+            err
+        );
+        return null;
+    }
+}
+
+/**
+ * Create a THREE.Mesh for a block that uses real textures if we managed to
+ * look them up and load them.  Falls back to a flat coloured material when no
+ * textures are available.
+ */
+function createBlockMeshWithTextures(
+    blockId: number,
+    loadedTextures: Map<string, THREE.Texture | null>
+): THREE.Mesh {
+    const facePaths = _getFaceTexturePaths(blockId);
+    if (!facePaths) {
+        return createBlockMesh(blockId); // Fallback to colored cube
+    }
+
+    const faceOrder: (string | null)[] = [
+        facePaths.right,
+        facePaths.left,
+        facePaths.top,
+        facePaths.bottom,
+        facePaths.front,
+        facePaths.back,
+    ];
+
+    const materials = faceOrder.map((path) => {
+        const texture = path ? loadedTextures.get(path) : null;
+        if (texture) {
+            return new THREE.MeshLambertMaterial({
+                map: texture,
+                transparent: true, // Assuming textures might have alpha
+            });
+        }
+        // Fallback material for this face if texture is missing or failed to load
+        return new THREE.MeshLambertMaterial({
+            color: colourFromBlockId(blockId),
+        });
+    });
+
+    const geom = new THREE.BoxGeometry(1, 1, 1);
+    return new THREE.Mesh(geom, materials);
+}
+
+/**
+ * Build and return a THREE.Mesh for a single block using a flat colour.
+ */
+function createBlockMesh(blockId: number): THREE.Mesh {
+    const geom = new THREE.BoxGeometry(1, 1, 1);
+    return new THREE.Mesh(
+        geom,
+        new THREE.MeshLambertMaterial({ color: colourFromBlockId(blockId) })
+    );
+}
+
+export interface SchematicData {
+    [coordStr: string]: number;
+}
+
+export interface GeneratePreviewOptions {
+    width?: number;
+    height?: number;
+    background?: string;
+    useTextures?: boolean;
+}
+
+/**
+ * Generate a small, isometric preview for the supplied schematic.
+ *
+ * @returns A base64 data-URL representing the rendered PNG, or an empty string on failure.
+ */
+export async function generateSchematicPreview(
+    schematicData: SchematicData,
+    {
+        width = 128,
+        height = 128,
+        background = "transparent",
+        useTextures = true,
+    }: GeneratePreviewOptions = {}
+): Promise<string> {
+    if (!schematicData || Object.keys(schematicData).length === 0) {
+        console.warn(
+            "generateSchematicPreview called with empty or undefined schematic – returning empty string."
+        );
+        return "";
+    }
+
+    const scene = new THREE.Scene();
+    const loadedTextures = new Map<string, THREE.Texture | null>();
+
+    if (useTextures && BlockTypeRegistry?.instance) {
+        try {
+            if (BlockTypeRegistry.instance.initialize) {
+                await BlockTypeRegistry.instance.initialize();
+            }
+
+            const texturePathsToLoad = new Set<string>();
+            Object.values(schematicData).forEach((blockId) => {
+                const facePaths = _getFaceTexturePaths(blockId);
+                if (facePaths) {
+                    Object.values(facePaths).forEach((p) => {
+                        if (p) texturePathsToLoad.add(p);
+                    });
+                }
+            });
+
+            const loadPromises = Array.from(texturePathsToLoad).map((path) =>
+                _loadTexture(path).then((tex) => {
+                    if (path) loadedTextures.set(path, tex);
+                })
+            );
+            await Promise.all(loadPromises);
+        } catch (err) {
+            console.warn(
+                "SchematicPreviewRenderer – error while loading textures, falling back to coloured cubes.",
+                err
+            );
+            // loadedTextures will remain empty or partially filled, leading to color fallbacks
+        }
+    }
+
+    const tmpVec = new THREE.Vector3();
+    let minX = Infinity,
+        minY = Infinity,
+        minZ = Infinity;
+    let maxX = -Infinity,
+        maxY = -Infinity,
+        maxZ = -Infinity;
+
+    Object.entries(schematicData).forEach(([coordStr, blockId]) => {
+        const [x, y, z] = coordStr.split(",").map((n) => parseInt(n, 10));
+
+        const mesh =
+            useTextures && loadedTextures.size > 0
+                ? createBlockMeshWithTextures(blockId, loadedTextures)
+                : createBlockMesh(blockId);
+
+        mesh.position.set(x, y, z);
+        scene.add(mesh);
+
+        minX = Math.min(x, minX);
+        minY = Math.min(y, minY);
+        minZ = Math.min(z, minZ);
+        maxX = Math.max(x, maxX);
+        maxY = Math.max(y, maxY);
+        maxZ = Math.max(z, maxZ);
+    });
+
+    const centreX = (minX + maxX) / 2;
+    const centreY = (minY + maxY) / 2;
+    const centreZ = (minZ + maxZ) / 2;
+
+    scene.children.forEach((obj) => {
+        if (obj instanceof THREE.Mesh) {
+            // Type guard for safety
+            obj.position.sub(tmpVec.set(centreX, centreY, centreZ));
+        }
+    });
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.7));
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
+    dirLight.position.set(5, 10, 7);
+    scene.add(dirLight);
+
+    const effectiveWidth =
+        schematicData && Object.keys(schematicData).length > 0
+            ? maxX - minX + 1
+            : 1;
+    const effectiveHeight =
+        schematicData && Object.keys(schematicData).length > 0
+            ? maxY - minY + 1
+            : 1;
+    const effectiveDepth =
+        schematicData && Object.keys(schematicData).length > 0
+            ? maxZ - minZ + 1
+            : 1;
+
+    const maxDim = Math.max(effectiveWidth, effectiveHeight, effectiveDepth, 1); // Ensure maxDim is at least 1
+    const aspect = width / height;
+    const frustumSize = maxDim * 1.5; // Adjusted padding slightly, ensure it's not too small
+
+    const camera = new THREE.OrthographicCamera(
+        (frustumSize * aspect) / -2,
+        (frustumSize * aspect) / 2,
+        frustumSize / 2,
+        frustumSize / -2,
+        0.1,
+        1000
+    );
+
+    const distance = maxDim * 2;
+    camera.position.set(distance, distance, distance);
+    camera.lookAt(scene.position); // Look at the center of the scene (which is 0,0,0 due to recentering)
+    camera.updateProjectionMatrix();
+
+    const renderer = new THREE.WebGLRenderer({
+        alpha: true,
+        antialias: true,
+        preserveDrawingBuffer: true,
+    });
+    renderer.setSize(width, height);
+    const clearAlpha = background === "transparent" ? 0 : 1;
+    const clearColor = background === "transparent" ? 0x000000 : background;
+    renderer.setClearColor(clearColor, clearAlpha);
+
+    renderer.render(scene, camera);
+
+    const dataUrl = renderer.domElement.toDataURL("image/png");
+
+    renderer.dispose();
+    scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+            obj.geometry.dispose();
+            if (Array.isArray(obj.material)) {
+                obj.material.forEach((m) => m.dispose());
+            } else if (obj.material) {
+                obj.material.dispose();
+            }
+        }
+    });
+    _textureCache.forEach((promise) => {
+        promise.then((texture) => {
+            if (texture) {
+                texture.dispose();
+            }
+        });
+    });
+    _textureCache.clear();
+
+    return dataUrl;
+}

--- a/src/js/utils/SchematicPreviewRenderer.ts
+++ b/src/js/utils/SchematicPreviewRenderer.ts
@@ -222,12 +222,16 @@ export interface GeneratePreviewOptions {
 export async function generateSchematicPreview(
     schematicData: SchematicData,
     {
-        width = 128,
-        height = 128,
+        width: inputWidth = 128,
+        height: inputHeight = 128,
         background = "transparent",
         useTextures = true,
     }: GeneratePreviewOptions = {}
 ): Promise<string> {
+    // Ensure width and height are positive for stable rendering
+    const renderWidth = Math.max(1, inputWidth);
+    const renderHeight = Math.max(1, inputHeight);
+
     if (!schematicData || Object.keys(schematicData).length === 0) {
         console.warn(
             "generateSchematicPreview called with empty or undefined schematic – returning empty string."
@@ -256,7 +260,7 @@ export async function generateSchematicPreview(
 
             const loadPromises = Array.from(texturePathsToLoad).map((path) =>
                 _loadTexture(path).then((tex) => {
-                    if (path) loadedTextures.set(path, tex);
+                    if (path) loadedTextures.set(path, tex); // Ensure path is not null before setting
                 })
             );
             await Promise.all(loadPromises);
@@ -269,7 +273,6 @@ export async function generateSchematicPreview(
         }
     }
 
-    const tmpVec = new THREE.Vector3();
     let minX = Infinity,
         minY = Infinity,
         minZ = Infinity;
@@ -277,16 +280,18 @@ export async function generateSchematicPreview(
         maxY = -Infinity,
         maxZ = -Infinity;
 
+    // Interface for instance groups
+    interface InstanceGroup {
+        type: "textured" | "color";
+        positions: THREE.Vector3[];
+        blockId: number; // Needed for fallback colors in textured groups too
+        facePaths?: FacePaths | null; // Only for textured type
+    }
+    const instanceGroups = new Map<string, InstanceGroup>();
+    const materialsToDispose: THREE.Material[] = []; // To keep track of materials for disposal
+
     Object.entries(schematicData).forEach(([coordStr, blockId]) => {
         const [x, y, z] = coordStr.split(",").map((n) => parseInt(n, 10));
-
-        const mesh =
-            useTextures && loadedTextures.size > 0
-                ? createBlockMeshWithTextures(blockId, loadedTextures)
-                : createBlockMesh(blockId);
-
-        mesh.position.set(x, y, z);
-        scene.add(mesh);
 
         minX = Math.min(x, minX);
         minY = Math.min(y, minY);
@@ -294,88 +299,191 @@ export async function generateSchematicPreview(
         maxX = Math.max(x, maxX);
         maxY = Math.max(y, maxY);
         maxZ = Math.max(z, maxZ);
+
+        let groupKey: string;
+        let currentFacePaths: FacePaths | null = null;
+
+        if (useTextures && BlockTypeRegistry?.instance) {
+            currentFacePaths = _getFaceTexturePaths(blockId);
+            if (currentFacePaths) {
+                // Key based on actual texture paths to group identical blocks
+                groupKey =
+                    "textured_" +
+                    JSON.stringify(Object.values(currentFacePaths).sort());
+                if (!instanceGroups.has(groupKey)) {
+                    instanceGroups.set(groupKey, {
+                        type: "textured",
+                        facePaths: currentFacePaths,
+                        blockId, // Store blockId for potential color fallbacks per face
+                        positions: [],
+                    });
+                }
+            } else {
+                // Fallback to color if texture paths can't be resolved
+                groupKey = "color_" + blockId;
+                if (!instanceGroups.has(groupKey)) {
+                    instanceGroups.set(groupKey, {
+                        type: "color",
+                        blockId,
+                        positions: [],
+                    });
+                }
+            }
+        } else {
+            // Color group if not using textures
+            groupKey = "color_" + blockId;
+            if (!instanceGroups.has(groupKey)) {
+                instanceGroups.set(groupKey, {
+                    type: "color",
+                    blockId,
+                    positions: [],
+                });
+            }
+        }
+        instanceGroups
+            .get(groupKey)!
+            .positions.push(new THREE.Vector3(x, y, z));
     });
 
     const centreX = (minX + maxX) / 2;
     const centreY = (minY + maxY) / 2;
     const centreZ = (minZ + maxZ) / 2;
 
-    scene.children.forEach((obj) => {
-        if (obj instanceof THREE.Mesh) {
-            // Type guard for safety
-            obj.position.sub(tmpVec.set(centreX, centreY, centreZ));
+    const sharedBoxGeometry = new THREE.BoxGeometry(1, 1, 1);
+
+    instanceGroups.forEach((group) => {
+        if (group.positions.length === 0) return;
+
+        let material: THREE.Material | THREE.Material[];
+
+        if (group.type === "textured" && group.facePaths) {
+            const faceOrder = [
+                group.facePaths.right,
+                group.facePaths.left,
+                group.facePaths.top,
+                group.facePaths.bottom,
+                group.facePaths.front,
+                group.facePaths.back,
+            ];
+            const groupMaterials = faceOrder.map((path) => {
+                const texture = path ? loadedTextures.get(path) : null;
+                if (texture) {
+                    return new THREE.MeshLambertMaterial({
+                        map: texture,
+                        transparent: true, // Assuming textures might have alpha
+                    });
+                }
+                return new THREE.MeshLambertMaterial({
+                    color: colourFromBlockId(group.blockId), // Fallback color for this face
+                });
+            });
+            materialsToDispose.push(...groupMaterials);
+            material = groupMaterials;
+        } else {
+            // Color group or fallback from textured if facePaths was null
+            const colorMaterial = new THREE.MeshLambertMaterial({
+                color: colourFromBlockId(group.blockId),
+            });
+            materialsToDispose.push(colorMaterial);
+            material = colorMaterial;
         }
+
+        const instancedMesh = new THREE.InstancedMesh(
+            sharedBoxGeometry,
+            material,
+            group.positions.length
+        );
+
+        const matrix = new THREE.Matrix4();
+        for (let i = 0; i < group.positions.length; i++) {
+            const pos = group.positions[i];
+            matrix.setPosition(
+                pos.x - centreX,
+                pos.y - centreY,
+                pos.z - centreZ
+            );
+            instancedMesh.setMatrixAt(i, matrix);
+        }
+        instancedMesh.instanceMatrix.needsUpdate = true;
+        scene.add(instancedMesh);
     });
+
+    // The old scene.children.forEach loop for recentering is no longer needed.
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.7));
     const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
-    dirLight.position.set(5, 10, 7);
+    dirLight.position.set(5, 10, 7); // Position relative to the group of blocks
     scene.add(dirLight);
 
     const effectiveWidth =
-        schematicData && Object.keys(schematicData).length > 0
-            ? maxX - minX + 1
-            : 1;
+        Object.keys(schematicData).length > 0 ? maxX - minX + 1 : 1;
     const effectiveHeight =
-        schematicData && Object.keys(schematicData).length > 0
-            ? maxY - minY + 1
-            : 1;
+        Object.keys(schematicData).length > 0 ? maxY - minY + 1 : 1;
     const effectiveDepth =
-        schematicData && Object.keys(schematicData).length > 0
-            ? maxZ - minZ + 1
-            : 1;
+        Object.keys(schematicData).length > 0 ? maxZ - minZ + 1 : 1;
 
-    const maxDim = Math.max(effectiveWidth, effectiveHeight, effectiveDepth, 1); // Ensure maxDim is at least 1
-    const aspect = width / height;
-    const frustumSize = maxDim * 1.5; // Adjusted padding slightly, ensure it's not too small
+    const maxDim = Math.max(effectiveWidth, effectiveHeight, effectiveDepth, 1);
+    const aspect = renderWidth / renderHeight;
+    // Adjust frustumSize based on how far blocks can be from the center after recentering
+    // The max deviation from center for any block coordinate is maxDim / 2.
+    // The camera needs to see from (0,0,0) out to these extents.
+    // A larger multiplier like 1.5 was okay, but let's try to be a bit tighter.
+    // Max extent from origin is roughly maxDim * sqrt(3)/2 for a corner, but orthographic.
+    // We need frustum to contain all blocks after they are centered around (0,0,0).
+    // So, from -maxDim/2 to +maxDim/2 for each axis. FrustumSize should be maxDim.
+    // A bit of padding is good, so 1.2 * maxDim.
+    const frustumSize = maxDim * 1.2 + 1; // Add 1 for single block case, ensure it's not too tight
 
     const camera = new THREE.OrthographicCamera(
         (frustumSize * aspect) / -2,
         (frustumSize * aspect) / 2,
         frustumSize / 2,
         frustumSize / -2,
-        0.1,
-        1000
+        0.1, // Near plane
+        maxDim * 5 // Far plane, needs to encompass the camera distance + scene depth
     );
 
-    const distance = maxDim * 2;
+    // Distance should ensure the entire schematic is visible.
+    // The camera looks at (0,0,0). Its position is (distance, distance, distance).
+    const distance = maxDim * 1.5; // Distance from origin for isometric view
     camera.position.set(distance, distance, distance);
-    camera.lookAt(scene.position); // Look at the center of the scene (which is 0,0,0 due to recentering)
+    camera.lookAt(scene.position); // scene.position is (0,0,0) as blocks are centered
     camera.updateProjectionMatrix();
 
     const renderer = new THREE.WebGLRenderer({
         alpha: true,
         antialias: true,
-        preserveDrawingBuffer: true,
+        preserveDrawingBuffer: true, // Necessary for toDataURL
     });
-    renderer.setSize(width, height);
+    renderer.setSize(renderWidth, renderHeight);
     const clearAlpha = background === "transparent" ? 0 : 1;
-    const clearColor = background === "transparent" ? 0x000000 : background;
-    renderer.setClearColor(clearColor, clearAlpha);
+    const clearColor = background === "transparent" ? 0x000000 : background; // Ensure type consistency
+    renderer.setClearColor(
+        new THREE.Color(clearColor as THREE.ColorRepresentation),
+        clearAlpha
+    );
 
     renderer.render(scene, camera);
 
     const dataUrl = renderer.domElement.toDataURL("image/png");
 
+    // Dispose WebGL resources
     renderer.dispose();
-    scene.traverse((obj) => {
-        if (obj instanceof THREE.Mesh) {
-            obj.geometry.dispose();
-            if (Array.isArray(obj.material)) {
-                obj.material.forEach((m) => m.dispose());
-            } else if (obj.material) {
-                obj.material.dispose();
-            }
+    sharedBoxGeometry.dispose();
+    materialsToDispose.forEach((mat) => {
+        if (Array.isArray(mat)) {
+            // Should not happen based on current logic, but good check
+            mat.forEach((m) => m.dispose());
+        } else if (mat) {
+            mat.dispose();
         }
     });
-    _textureCache.forEach((promise) => {
-        promise.then((texture) => {
-            if (texture) {
-                texture.dispose();
-            }
-        });
-    });
-    _textureCache.clear();
+
+    // Textures loaded via _textureLoader are potentially shared via THREE.Cache.
+    // Disposing them here can cause flickers if the main app uses them.
+    // We will clear our local promise cache, but not dispose the textures themselves,
+    // as they are managed by THREE.Cache and may be used elsewhere in the application.
+    _textureCache.clear(); // Clear the local promise cache for this renderer instance.
 
     return dataUrl;
 }


### PR DESCRIPTION
Adds a Schematic Tab to the BlockToolsSidebar
- Schematics get a random ID in the database instead of being keyed by the prompt
- Adds a simple migration step for the Schematic DB store with a flag when it has been run
- ThreeJS helper for rendering a png of a schematic using the Texture Atlas (or generating uniform colours as a fallback)
- Press R to rotate schematics in Schematic Placement Tool
- Selection Tool can save schematics (Press T to save, added to tooltip)