### PR TITLE
Missing block faces + Export file name

### DIFF
--- a/src/js/ImportExport.tsx
+++ b/src/js/ImportExport.tsx
@@ -663,14 +663,14 @@ export const exportMapFile = async (terrainBuilderRef, environmentBuilderRef) =>
         const jsonContent = JSON.stringify(exportData, null, 2);
         const jsonBlob = new Blob([jsonContent], { type: "application/json" });
 
-        // Add terrain.json to the zip file root
-        zip.file("terrain.json", jsonBlob);
+        // Add map.json to the zip file root
+        zip.file("map.json", jsonBlob);
 
         const zipBlob = await zip.generateAsync({ type: "blob" });
 
         loadingManager.updateLoading("Preparing download...", 95);
 
-        // Download ZIP (which now includes terrain.json)
+        // Download ZIP (which now includes map.json)
         const zipUrl = URL.createObjectURL(zipBlob);
         const zipLink = document.createElement("a");
         zipLink.href = zipUrl;

--- a/src/js/chunks/ChunkSystem.tsx
+++ b/src/js/chunks/ChunkSystem.tsx
@@ -152,6 +152,9 @@ class ChunkSystem {
                 );
             }
 
+            // Clear cached block types so neighbouring face visibility is recalculated
+            this._chunkManager.clearBlockTypeCache({ x, y, z }, 2);
+
             chunksToUpdate.add(chunkId);
 
             if (!chunkOptions.has(chunkId)) {
@@ -245,6 +248,9 @@ class ChunkSystem {
                 },
                 block.id
             );
+
+            // Newly placed blocks may expose/occlude neighbouring faces; clear a smaller cache radius
+            this._chunkManager.clearBlockTypeCache({ x, y, z }, 1);
 
             chunksToUpdate.add(chunkId);
 


### PR DESCRIPTION
- Fixed issue with neighbouring faces not rendering post deletion by invalidating the cache for the neighbouring blocks
- Export directly to map.json to save renaming within the SDK